### PR TITLE
fix: add error states to data-fetching pages (#27 #28)

### DIFF
--- a/frontend/src/__tests__/pages/DetailedNatalReportPage.test.tsx
+++ b/frontend/src/__tests__/pages/DetailedNatalReportPage.test.tsx
@@ -125,6 +125,13 @@ const { mockChartData } = vi.hoisted(() => {
 
 vi.mock('../../components', () => ({
   AppLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  EmptyState: ({ title, description, actionText, onAction }: Record<string, unknown>) => (
+    <div data-testid="error-state">
+      <h2>{title as string}</h2>
+      <p>{description as string}</p>
+      <button onClick={onAction as () => void}>{actionText as string}</button>
+    </div>
+  ),
 }));
 
 vi.mock('../../services/chart.service', () => ({
@@ -569,6 +576,25 @@ describe('DetailedNatalReportPage', () => {
       renderWithProviders(createElement(DetailedNatalReportPage));
       const mainContainer = document.querySelector('.max-w-7xl');
       expect(mainContainer).toBeInTheDocument();
+    });
+  });
+
+  describe('Error State', () => {
+    it('should show error state when chart fetch fails', async () => {
+      vi.mocked(chartService.getChart).mockRejectedValue(new Error('Network error'));
+      renderWithProviders(createElement(DetailedNatalReportPage));
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load report')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+
+    it('should show try again button in error state', async () => {
+      vi.mocked(chartService.getChart).mockRejectedValue(new Error('Server error'));
+      renderWithProviders(createElement(DetailedNatalReportPage));
+      await waitFor(() => {
+        expect(screen.getByText('Try Again')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/__tests__/pages/SolarReturnAnnualReportPage.test.tsx
+++ b/frontend/src/__tests__/pages/SolarReturnAnnualReportPage.test.tsx
@@ -50,6 +50,13 @@ vi.mock('../../components/ui/Button', () => ({
 // Mock the components barrel to avoid circular import SyntaxError
 vi.mock('../../components', () => ({
   AppLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  EmptyState: ({ title, description, actionText, onAction }: Record<string, unknown>) => (
+    <div data-testid="error-state">
+      <h2>{title as string}</h2>
+      <p>{description as string}</p>
+      <button onClick={onAction as () => void}>{actionText as string}</button>
+    </div>
+  ),
 }));
 
 // Mock the API module so the component's useEffect fetches controlled data
@@ -680,6 +687,25 @@ describe('SolarReturnAnnualReportPage', () => {
         },
         { timeout: 3000 },
       );
+    });
+  });
+
+  describe('Error State', () => {
+    it('should show error state when solar return fetch fails', async () => {
+      mockApiGet.mockRejectedValue(new Error('Network error'));
+      renderWithProviders(createElement(SolarReturnAnnualReportPage));
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load solar return report')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+
+    it('should show try again button in error state', async () => {
+      mockApiGet.mockRejectedValue(new Error('Server error'));
+      renderWithProviders(createElement(SolarReturnAnnualReportPage));
+      await waitFor(() => {
+        expect(screen.getByText('Try Again')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/pages/DailyBriefingPage.tsx
+++ b/frontend/src/pages/DailyBriefingPage.tsx
@@ -16,7 +16,7 @@ import { useAuth } from '../hooks/useAuth';
 import { useTodayTransits } from '../hooks';
 
 // Components
-import { AppLayout } from '../components';
+import { AppLayout, EmptyState } from '../components';
 import MoonPhaseCard from '../components/astrology/MoonPhaseCard';
 import TransitTimelineCard from '../components/astrology/TransitTimelineCard';
 import type { MoonPhaseType } from '../components/astrology/MoonPhaseCard';
@@ -174,7 +174,7 @@ const DailyBriefingPage: React.FC = () => {
   const hasMarkedViewed = useRef(false);
 
   // Fetch real transit data
-  const { data: transitData, isLoading: _isLoading } = useTodayTransits();
+  const { data: transitData, isLoading: _isLoading, error: transitError } = useTodayTransits();
 
   // Derive moon phase from transit data
   const moonPhase: MoonPhaseData = useMemo(() => {
@@ -262,10 +262,29 @@ const DailyBriefingPage: React.FC = () => {
     return 'Good Evening';
   };
 
+  if (transitError) {
+    return (
+      <AppLayout>
+        <Helmet>
+          <title>Daily Briefing – AstroVerse</title>
+        </Helmet>
+        <div className="max-w-[860px] mx-auto px-4 sm:px-6 py-10">
+          <EmptyState
+            icon="error"
+            title="Failed to load daily briefing"
+            description={transitError instanceof Error ? transitError.message : 'Unable to fetch transit data'}
+            actionText="Try Again"
+            onAction={() => window.location.reload()}
+          />
+        </div>
+      </AppLayout>
+    );
+  }
+
   return (
     <AppLayout>
       <Helmet>
-        <title>Daily Briefing � AstroVerse</title>
+        <title>Daily Briefing – AstroVerse</title>
       </Helmet>
 
       <div

--- a/frontend/src/pages/DetailedNatalReportPage.tsx
+++ b/frontend/src/pages/DetailedNatalReportPage.tsx
@@ -10,7 +10,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 
 // Components
-import { AppLayout } from '../components';
+import { AppLayout, EmptyState } from '../components';
 import { Button } from '../components/ui/Button';
 import ElementalBalance from '../components/astrology/ElementalBalance';
 import PlanetaryPositionCard from '../components/astrology/PlanetaryPositionCard';
@@ -108,7 +108,7 @@ const DetailedNatalReportPage: React.FC = () => {
   );
   const [apiChart, setApiChart] = useState<Chart | null>(null);
   const [_isLoadingChart, setIsLoadingChart] = useState(false);
-  const [_chartError, setChartError] = useState<string | null>(null);
+  const [chartError, setChartError] = useState<string | null>(null);
 
   // PDF generation hook
   const {
@@ -242,6 +242,22 @@ const DetailedNatalReportPage: React.FC = () => {
       }
     }
   };
+
+  if (chartError) {
+    return (
+      <AppLayout>
+        <div className="max-w-7xl mx-auto px-6 lg:px-20 py-10">
+          <EmptyState
+            icon="error"
+            title="Failed to load report"
+            description={chartError}
+            actionText="Try Again"
+            onAction={() => window.location.reload()}
+          />
+        </div>
+      </AppLayout>
+    );
+  }
 
   return (
     <AppLayout>

--- a/frontend/src/pages/SavedChartsGalleryPage.tsx
+++ b/frontend/src/pages/SavedChartsGalleryPage.tsx
@@ -23,7 +23,7 @@ type FilterFolder = 'all' | 'personal' | 'clients' | 'relationships' | 'favorite
 
 export const SavedChartsGalleryPage: React.FC = () => {
   const navigate = useNavigate();
-  const { charts, isLoading, deleteChart } = useCharts();
+  const { charts, isLoading, error: chartsError, deleteChart } = useCharts();
 
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [sortBy, setSortBy] = useState<SortBy>('dateAdded');
@@ -332,7 +332,17 @@ export const SavedChartsGalleryPage: React.FC = () => {
           </div>
 
           {/* Gallery Grid */}
-          {isLoading ? (
+          {chartsError ? (
+            <div className="flex items-center justify-center py-20">
+              <EmptyState
+                icon="error"
+                title="Failed to load charts"
+                description={typeof chartsError === 'string' ? chartsError : 'Unable to fetch your charts'}
+                actionText="Try Again"
+                onAction={() => window.location.reload()}
+              />
+            </div>
+          ) : isLoading ? (
             <div className="flex items-center justify-center py-20">
               <div className="text-center">
                 <div className="w-16 h-16 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto mb-4" />

--- a/frontend/src/pages/SolarReturnAnnualReportPage.tsx
+++ b/frontend/src/pages/SolarReturnAnnualReportPage.tsx
@@ -10,7 +10,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 
 // Components
-import { AppLayout } from '../components';
+import { AppLayout, EmptyState } from '../components';
 import { Button } from '../components/ui/Button';
 
 // Hooks & Services
@@ -134,7 +134,7 @@ const SolarReturnAnnualReportPage: React.FC = () => {
 
   const [activeAccordion, setActiveAccordion] = useState<string | null>(null);
   const [_isLoadingSolar, setIsLoadingSolar] = useState(false);
-  const [_solarError, setSolarError] = useState<string | null>(null);
+  const [solarError, setSolarError] = useState<string | null>(null);
   const [rawSolarReturn, setRawSolarReturn] = useState<Record<string, unknown> | null>(null);
 
   // PDF generation hook
@@ -228,6 +228,22 @@ const SolarReturnAnnualReportPage: React.FC = () => {
       downloadReport(filename);
     }
   };
+
+  if (solarError) {
+    return (
+      <AppLayout>
+        <div className="max-w-7xl mx-auto px-6 lg:px-20 py-10">
+          <EmptyState
+            icon="error"
+            title="Failed to load solar return report"
+            description={solarError}
+            actionText="Try Again"
+            onAction={() => window.location.reload()}
+          />
+        </div>
+      </AppLayout>
+    );
+  }
 
   return (
     <AppLayout>

--- a/frontend/src/pages/SubscriptionPage.tsx
+++ b/frontend/src/pages/SubscriptionPage.tsx
@@ -6,6 +6,7 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AppLayout } from '../components/AppLayout';
+import { EmptyState } from '../components';
 import UsageMeter from '../components/UsageMeter';
 import { useCharts } from '../hooks';
 import type { Tier } from '../components/UsageMeter';
@@ -177,7 +178,7 @@ const TIER_LIMITS: Record<string, number> = {
 
 export default function SubscriptionPage() {
   const navigate = useNavigate();
-  const { charts, fetchCharts } = useCharts();
+  const { charts, fetchCharts, error: chartsError } = useCharts();
 
   useEffect(() => {
     void fetchCharts();
@@ -186,6 +187,26 @@ export default function SubscriptionPage() {
   const currentTier = (charts.length > 0 ? 'free' : 'free') as Tier;
   const chartCount = charts.length;
   const tierLimit = TIER_LIMITS[currentTier] ?? 3;
+
+  if (chartsError) {
+    return (
+      <AppLayout>
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-white mb-2">Subscription</h1>
+          <p className="text-slate-200">
+            Manage your plan and usage
+          </p>
+        </div>
+        <EmptyState
+          icon="error"
+          title="Failed to load charts"
+          description={typeof chartsError === 'string' ? chartsError : 'Unable to fetch chart data'}
+          actionText="Try Again"
+          onAction={() => window.location.reload()}
+        />
+      </AppLayout>
+    );
+  }
 
   return (
     <AppLayout>


### PR DESCRIPTION
## Summary

Adds error state handling to 5 data-fetching pages for issues #27 and #28.

### Changes
- **DetailedNatalReportPage**: Renamed `_chartError` → `chartError`, added error guard with EmptyState before main return
- **SolarReturnAnnualReportPage**: Renamed `_solarError` → `solarError`, added error guard with EmptyState before main return
- **DailyBriefingPage**: Destructured `error` from `useTodayTransits()`, added error guard with EmptyState
- **SubscriptionPage**: Destructured `error` from `useCharts()`, added error guard with EmptyState
- **SavedChartsGalleryPage**: Destructured `error` from `useCharts()`, added error EmptyState in gallery conditional

### Key decisions
- **Loading states kept suppressed** (prefixed with `_`) — pages use fallback data
- **Error-only approach**: Only error state handling is added

### Tests
- Added EmptyState to component mocks in both test files
- Added 2 new test cases for DetailedNatalReportPage error state
- Added 2 new test cases for SolarReturnAnnualReportPage error state
- All 4577 tests pass (0 failures)

Closes #27
Closes #28