### PR TITLE
fix: keyboard focus management with focus-visible outline (#32)

### DIFF
--- a/frontend/src/assets/styles/globals.css
+++ b/frontend/src/assets/styles/globals.css
@@ -194,9 +194,15 @@
     outline-offset: 2px;
   }
 
-  /* Remove default outline */
-  * {
+  /* Focus management - visible outline for keyboard navigation only */
+  *:focus {
     outline: none;
+  }
+
+  *:focus-visible {
+    outline: 2px solid var(--color-primary, #6366f1);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 
   /* Scrollbar */


### PR DESCRIPTION
## Changes
- Replace `* { outline: none }` with `*:focus-visible` ring for keyboard users
- Skip-to-content link already existed in AppLayout
- Modal focus traps already implemented

## Testing
- TypeScript: clean
- 4577 tests passing