### PR TITLE
fix: add HelmetProvider to fix login/register page crash

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@
 import { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { HelmetProvider } from 'react-helmet-async';
 
 // Components
 import { ProtectedRoute } from './components/ProtectedRoute';
@@ -61,6 +62,7 @@ const queryClient = new QueryClient({
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
+      <HelmetProvider>
       <div className="min-h-screen bg-cosmic-page">
         <ServiceWorkerUpdateBanner />
         <ErrorBoundary>
@@ -250,6 +252,7 @@ function App() {
           </Suspense>
         </ErrorBoundary>
       </div>
+      </HelmetProvider>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Fix: Login & Register pages crash on load

### Problem
All pages using `<Helmet>` from `react-helmet-async` crashed with:
```
TypeError: Cannot read properties of undefined (reading 'add')
    at HelmetDispatcher.init
```

### Root Cause
`react-helmet-async@3.0.0` requires a `<HelmetProvider>` wrapper at the app root.

### Fix
Added `<HelmetProvider>` wrapping the entire app in `App.tsx`.

### Testing
- 4577 tests pass
- Login page renders correctly
- Register page renders correctly