### PR TITLE
fix(lint): remove unused parsed variable in billing controller

### DIFF
--- a/backend/src/modules/billing/controllers/billing.controller.ts
+++ b/backend/src/modules/billing/controllers/billing.controller.ts
@@ -30,7 +30,7 @@ function isValidRedirectUrl(url: string): boolean {
     'http://localhost:3001',
   ];
   try {
-    const parsed = new URL(url);
+    new URL(url);
     return allowedOrigins.some(origin => url.startsWith(origin));
   } catch {
     return false;

--- a/backend/src/modules/cards/services/card-image.service.ts
+++ b/backend/src/modules/cards/services/card-image.service.ts
@@ -292,7 +292,7 @@ export class CardImageService {
       return null;
     } finally {
       if (page) {
-        await page.close().catch(() => {});
+        await page.close().catch(() => { /* page close is best-effort — ignore errors */ });
       }
     }
   }


### PR DESCRIPTION
## Summary
Removes unused `parsed` variable in `billing.controller.ts` line 33.

The `new URL(url)` is still called for validation (throws on invalid URLs), but the result is no longer assigned since it was never used.

Fixes the ESLint error: `'parsed' is assigned a value but never used` that is causing the **backend-test CI job to fail**.

## Test Plan
- [x] CI backend lint should pass

Auto-fix from review cron.