### PR TITLE
fix(test): lock CalendarPage test time with vi.useFakeTimers

### DIFF
--- a/frontend/src/__tests__/pages/CalendarPage.test.tsx
+++ b/frontend/src/__tests__/pages/CalendarPage.test.tsx
@@ -121,7 +121,8 @@ describe('CalendarPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Lock time to May 1, 2026 so month assertions stay deterministic
-    vi.useFakeTimers({ now: new Date(2026, 4, 1).getTime() });
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2026, 4, 1));
   });
 
   describe('Page Rendering', () => {

--- a/frontend/src/__tests__/pages/CalendarPage.test.tsx
+++ b/frontend/src/__tests__/pages/CalendarPage.test.tsx
@@ -120,6 +120,8 @@ const renderWithProviders = (ui: React.ReactElement) => {
 describe('CalendarPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Lock time to May 1, 2026 so month assertions stay deterministic
+    vi.useFakeTimers({ now: new Date(2026, 4, 1).getTime() });
   });
 
   describe('Page Rendering', () => {


### PR DESCRIPTION
## Summary
CalendarPage navigation tests used hardcoded month names (May 2026, April 2026, June 2026) that became stale as the real date advanced. This caused  CI to fail on **every** PR, even unrelated ones.

## Fix
Add  in  to lock the date to May 1, 2026. All month name and day count assertions now stay deterministic.

Closes #158