### PR TITLE
fix(a11y,vite): use import.meta.env for Vite, add id/htmlFor to form inputs

### DIFF
--- a/frontend/src/components/ErrorFallback.tsx
+++ b/frontend/src/components/ErrorFallback.tsx
@@ -42,7 +42,7 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error, retry }) => {
         </p>
 
         {/* Technical Details (collapsible in production) */}
-        {process.env.NODE_ENV === 'development' && error.message && (
+        {import.meta.env.DEV && error.message && (
           <details className="mb-6">
             <summary className="text-sm text-purple-300 cursor-pointer hover:text-purple-200 transition-colors">
               Technical Details

--- a/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.tsx
@@ -42,7 +42,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     // Log error to console in development
-    if (process.env.NODE_ENV === 'development') {
+    if (import.meta.env.DEV) {
       console.error('ErrorBoundary caught an error:', error, errorInfo);
     }
 
@@ -55,7 +55,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     });
 
     // In production, you might want to send this to an error reporting service
-    if (process.env.NODE_ENV === 'production') {
+    if (import.meta.env.PROD) {
       // Example: Send to error tracking service
       // logErrorToService(error, errorInfo);
     }
@@ -112,7 +112,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                     'An unexpected error occurred. Please try refreshing the page.'}
                 </p>
 
-                {process.env.NODE_ENV === 'development' && error && (
+                {import.meta.env.DEV && error && (
                   <details className="mt-4">
                     <summary className="cursor-pointer text-sm font-medium mb-2">
                       Error Details

--- a/frontend/src/pages/TransitForecastPage.tsx
+++ b/frontend/src/pages/TransitForecastPage.tsx
@@ -364,8 +364,9 @@ const TransitForecastPage: React.FC = () => {
         {/* Chart Selector & Filters */}
         <div className="flex flex-col md:flex-row gap-4 mb-8">
           <div className="flex-grow">
-            <label className="block text-sm text-slate-400 mb-2">Select Chart</label>
+            <label htmlFor="chart-selector" className="block text-sm text-slate-400 mb-2">Select Chart</label>
             <select
+              id="chart-selector"
               value={selectedChartId}
               onChange={(e) => setSelectedChartId(e.target.value)}
               className="w-full px-4 py-2 bg-surface border border-glass-border rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-primary/50"
@@ -381,8 +382,9 @@ const TransitForecastPage: React.FC = () => {
 
           <div className="flex gap-4 items-end">
             <div>
-              <label className="block text-sm text-slate-400 mb-2">Start Date</label>
+              <label htmlFor="start-date-input" className="block text-sm text-slate-400 mb-2">Start Date</label>
               <input
+                id="start-date-input"
                 type="date"
                 value={startDate}
                 onChange={(e) => setStartDate(e.target.value)}
@@ -391,8 +393,9 @@ const TransitForecastPage: React.FC = () => {
               />
             </div>
             <div>
-              <label className="block text-sm text-slate-400 mb-2">End Date</label>
+              <label htmlFor="end-date-input" className="block text-sm text-slate-400 mb-2">End Date</label>
               <input
+                id="end-date-input"
                 type="date"
                 value={endDate}
                 onChange={(e) => setEndDate(e.target.value)}


### PR DESCRIPTION
## Summary
- Replace `process.env.NODE_ENV` with `import.meta.env.DEV`/`import.meta.env.PROD` in ErrorFallback and ErrorBoundary (Vite standard)
- Add explicit `id` and `htmlFor` attributes to TransitForecastPage form inputs for WCAG 2.1 AA compliance

## Changes
### #157 — process.env → import.meta.env
- `frontend/src/components/ErrorFallback.tsx`: `process.env.NODE_ENV === 'development'` → `import.meta.env.DEV`
- `frontend/src/components/ui/ErrorBoundary.tsx`: same replacement for both DEV and PROD checks

### #140 — Form input accessibility
- `frontend/src/pages/TransitForecastPage.tsx`: Added `id` attributes on select/input elements and matching `htmlFor` on labels

## Test Plan
- [x] Frontend typecheck passes (`npx tsc --noEmit`)
- [x] Existing tests unaffected (no logic changes, only attribute additions)
- [ ] CI green

Closes #157
Closes #140