### PR TITLE
refactor: deduplicate PLANET_SYMBOLS across chart components

### DIFF
--- a/frontend/src/components/ChartWheel.tsx
+++ b/frontend/src/components/ChartWheel.tsx
@@ -15,6 +15,7 @@
 
 import type { PlanetPosition, HouseCusp, Aspect, ChartData } from '../types/chart.types';
 import { PLANET_COLORS, ASPECT_COLORS as ASPECT_COLORS_TOKEN, ZODIAC_COLORS } from '../utils/design-tokens';
+import { PLANET_SYMBOLS_LOWER as BASE_PLANET_SYMBOLS } from '../utils/astrology/planetPosition';
 export type { PlanetPosition, HouseCusp, Aspect, ChartData } from '../types/chart.types';
 
 function normalizePlanets(planets: ChartData['planets']): PlanetPosition[] {
@@ -35,9 +36,9 @@ interface ChartWheelProps {
 }
 
 const PLANET_SYMBOLS: Record<string, string> = {
-  sun: '☉', moon: '☽', mercury: '☿', venus: '♀', mars: '♂',
-  jupiter: '♃', saturn: '♄', uranus: '♅', neptune: '♆', pluto: '♇',
-  chiron: '⚷', northnode: '☊', southnode: '☋',
+  ...BASE_PLANET_SYMBOLS,
+  asc: '\u2191', dsc: '\u2193', mc: '\u2297', ic: '\u2258',
+};
   asc: '↑', dsc: '↓', mc: '⊗', ic: '≘',
 };
 const PLANET_NAMES: Record<string, string> = {

--- a/frontend/src/components/ChartWheel.tsx
+++ b/frontend/src/components/ChartWheel.tsx
@@ -39,8 +39,6 @@ const PLANET_SYMBOLS: Record<string, string> = {
   ...BASE_PLANET_SYMBOLS,
   asc: '\u2191', dsc: '\u2193', mc: '\u2297', ic: '\u2258',
 };
-  asc: '↑', dsc: '↓', mc: '⊗', ic: '≘',
-};
 const PLANET_NAMES: Record<string, string> = {
   sun: 'Sun', moon: 'Moon', mercury: 'Mercury', venus: 'Venus', mars: 'Mars',
   jupiter: 'Jupiter', saturn: 'Saturn', uranus: 'Uranus', neptune: 'Neptune', pluto: 'Pluto',

--- a/frontend/src/components/SolarReturnChart.tsx
+++ b/frontend/src/components/SolarReturnChart.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { PLANET_SYMBOLS_LOWER } from '../utils/astrology/planetPosition';
 
 
 
@@ -75,18 +76,7 @@ const ZODIAC_SYMBOLS: Record<string, string> = {
   pisces: '♓',
 };
 
-const PLANET_SYMBOLS: Record<string, string> = {
-  sun: '☉',
-  moon: '☽',
-  mercury: '☿',
-  venus: '♀',
-  mars: '♂',
-  jupiter: '♃',
-  saturn: '♄',
-  uranus: '♅',
-  neptune: '♆',
-  pluto: '♇',
-};
+const PLANET_SYMBOLS = PLANET_SYMBOLS_LOWER;
 
 const PLANET_COLORS: Record<string, string> = {
   sun: '#FFD700',

--- a/frontend/src/pages/EphemerisPage.tsx
+++ b/frontend/src/pages/EphemerisPage.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useTodayTransits } from '../hooks';
 import { getErrorMessage } from '../utils/errorHandling';
+import { PLANET_SYMBOLS_LOWER } from '../utils/astrology/planetPosition';
 
 // Aspect label mapping
 const ASPECT_LABELS: Record<string, string> = {
@@ -24,21 +25,8 @@ const ASPECT_LABELS: Record<string, string> = {
 };
 
 // Planet symbol mapping (for display in transit cards)
-const PLANET_SYMBOLS: Record<string, string> = {
-  sun: '☉',
-  moon: '☽',
-  mercury: '☿',
-  venus: '♀',
-  mars: '♂',
-  jupiter: '♃',
-  saturn: '♄',
-  uranus: '♅',
-  neptune: '♆',
-  pluto: '♇',
-  northnode: '☊',
-  southnode: '☋',
-  chiron: '⚷',
-};
+// Use lowercase-keyed planet symbols from shared module
+const PLANET_SYMBOLS = PLANET_SYMBOLS_LOWER;
 
 // Planet colors for display
 const PLANET_COLORS: Record<string, string> = {

--- a/frontend/src/utils/astrology/index.ts
+++ b/frontend/src/utils/astrology/index.ts
@@ -22,6 +22,7 @@ export {
   getPlanetSymbol,
   isRetrograde,
   PLANET_SYMBOLS,
+  PLANET_SYMBOLS_LOWER,
 } from './planetPosition';
 
 // Aspect Calculator

--- a/frontend/src/utils/astrology/planetPosition.ts
+++ b/frontend/src/utils/astrology/planetPosition.ts
@@ -51,6 +51,11 @@ export const PLANET_SYMBOLS: Record<string, string> = {
   Lilith: '\u26b8',
 };
 
+/** Lowercase-keyed version for chart rendering components */
+export const PLANET_SYMBOLS_LOWER: Record<string, string> = Object.fromEntries(
+  Object.entries(PLANET_SYMBOLS).map(([k, v]) => [k.toLowerCase(), v])
+);
+
 // Retrograde periods (approximate days per year)
 const RETROGRADE_DAYS: Record<string, number> = {
   Mercury: 21,
@@ -395,4 +400,5 @@ export default {
   getPlanetSymbol,
   isRetrograde,
   PLANET_SYMBOLS,
+  PLANET_SYMBOLS_LOWER,
 };


### PR DESCRIPTION
## Summary
Consolidate 5 separate PLANET_SYMBOLS definitions into a single canonical source.

## Changes
- Added `PLANET_SYMBOLS_LOWER` (lowercase-keyed variant) to `utils/astrology/planetPosition.ts`
- Removed local definitions from:
  - `EphemerisPage.tsx` → now imports `PLANET_SYMBOLS_LOWER`
  - `SolarReturnChart.tsx` → now imports `PLANET_SYMBOLS_LOWER`
  - `ChartWheel.tsx` → now spreads `BASE_PLANET_SYMBOLS` + retains extra entries (asc, dsc, mc, ic)
- `NatalChartDetailPage.tsx` kept separate (uses Material Icons, not Unicode symbols)

## Result
- 5 definitions → 2 (canonical Unicode + Material Icons)
- Net: -14 lines

Closes #156