### PR TITLE
fix: gate CORS localhost origins behind NODE_ENV check

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -53,8 +53,12 @@ app.use(helmet({
 }));
 
 // CORS - Cross-Origin Resource Sharing
+const corsOrigins = [FRONTEND_URL];
+if (process.env.NODE_ENV !== 'production') {
+  corsOrigins.push('http://localhost:3000', 'http://localhost:5173', 'http://localhost:3001', 'http://localhost:3002');
+}
 app.use(cors({
-  origin: [FRONTEND_URL, 'http://localhost:3000', 'http://localhost:5173', 'http://localhost:3001', 'http://localhost:3002'],
+  origin: corsOrigins,
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'X-CSRF-Token'],


### PR DESCRIPTION
## Changes
- **server.ts**: CORS origin array now only includes localhost entries when `NODE_ENV !== 'production'`
- In production, only `FRONTEND_URL` is allowed as a CORS origin

## Related Issues
- Fixes #187 (remaining CORS localhost part — billing was fixed in PR #198)

## Security Impact
Prevents production server from accepting requests from `localhost:3000`, `localhost:5173`, `localhost:3001`, `localhost:3002` — which should never be valid in production.

## Quality
- No behavior change in development
- Production: strictly more secure

---
*Automated review by Hermes Agent*