### PR TITLE
fix: replace raw fetch() with api client in BirthDataForm

### DIFF
--- a/frontend/src/components/BirthDataForm.tsx
+++ b/frontend/src/components/BirthDataForm.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useCreateChart, useCalculateChart } from '../hooks';
+import api from '../services/api';
 import { useChartStore } from '../stores/chartStore';
 
 // Error Message Component with Icon
@@ -104,21 +105,16 @@ export function BirthDataForm({
     }
 
     try {
-      const apiBase = import.meta.env.VITE_API_URL ?? '';
-      const response = await fetch(
-        `${apiBase}/api/v1/location/autocomplete?input=${encodeURIComponent(query)}`,
-      );
+      const result = await api.get<{
+        predictions: { description: string; lat?: number; lon?: number; mainText?: string; secondaryText?: string }[];
+      }>('/v1/location/autocomplete', { params: { input: query } });
 
-      if (!response.ok) {
+      if (!result.data) {
         setPlaceSuggestions([]);
         return;
       }
 
-      const result = await response.json() as {
-        predictions: { description: string; lat?: number; lon?: number; mainText?: string; secondaryText?: string }[];
-      };
-
-      const predictions = result.predictions ?? [];
+      const predictions = result.data?.predictions ?? [];
       if (predictions.length > 0) {
         // Map backend prediction format to the component's expected format
         const mapped = predictions.map((p) => ({
@@ -147,13 +143,11 @@ export function BirthDataForm({
     // Auto-detect timezone from coordinates
     let timezone: string | undefined;
     try {
-      const apiBase = import.meta.env.VITE_API_URL ?? '';
-      const tzResp = await fetch(
-        `${apiBase}/api/v1/location/timezone?lat=${lat}&lon=${lon}`,
+      const tzResp = await api.get<{ data?: { timezone?: string } }>(
+        '/v1/location/timezone', { params: { lat, lon } },
       );
-      if (tzResp.ok) {
-        const tzData = await tzResp.json() as { data?: { timezone?: string } };
-        timezone = tzData.data?.timezone;
+      if (tzResp.data?.data?.timezone) {
+        timezone = tzResp.data.data.timezone;
       }
     } catch {
       // fallback: compute rough timezone from longitude

--- a/frontend/src/components/__tests__/BirthDataForm.test.tsx
+++ b/frontend/src/components/__tests__/BirthDataForm.test.tsx
@@ -43,8 +43,11 @@ vi.mock('../stores/chartStore', () => ({
   },
 }));
 
-// Mock fetch for geocoding API
-global.fetch = vi.fn();
+// Mock api client
+const mockApiGet = vi.fn();
+vi.mock('../../services/api', () => ({
+  default: { get: (...args: any[]) => mockApiGet(...args) },
+}));
 
 // Create a test wrapper with QueryClientProvider
 const createTestWrapper = () => {
@@ -68,10 +71,9 @@ const renderWithQueryClient = (ui: React.ReactElement) => {
 describe('BirthDataForm Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Mock successful fetch responses for place autocomplete
-    (global.fetch as any).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ predictions: [] }),
+    // Mock successful api responses for place autocomplete
+    mockApiGet.mockResolvedValue({
+      data: { predictions: [] },
     });
   });
 
@@ -296,18 +298,16 @@ describe('BirthDataForm Component', () => {
     it('should show place suggestions when typing valid place name', async () => {
       const user = userEvent.setup();
       // The component fetches from /api/v1/location/autocomplete which returns { predictions: [...] }
-      (global.fetch as any).mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            predictions: [
-              {
-                description: 'New York, NY, USA',
-                lat: 40.7128,
-                lon: -74.006,
-              },
-            ],
-          }),
+      mockApiGet.mockResolvedValue({
+        data: {
+          predictions: [
+            {
+              description: 'New York, NY, USA',
+              lat: 40.7128,
+              lon: -74.006,
+            },
+          ],
+        },
       });
 
       renderWithQueryClient(<BirthDataForm />);
@@ -344,31 +344,27 @@ describe('BirthDataForm Component', () => {
       const user = userEvent.setup();
       // First call: autocomplete returns predictions
       // Second call: timezone lookup (we'll mock both)
-      (global.fetch as any).mockImplementation((url: string) => {
+      mockApiGet.mockImplementation((url: string) => {
         if (url.includes('autocomplete')) {
           return Promise.resolve({
-            ok: true,
-            json: () =>
-              Promise.resolve({
-                predictions: [
-                  {
-                    description: 'London, UK',
-                    lat: 51.5074,
-                    lon: -0.1278,
-                  },
-                ],
-              }),
+            data: {
+              predictions: [
+                {
+                  description: 'London, UK',
+                  lat: 51.5074,
+                  lon: -0.1278,
+                },
+              ],
+            },
           });
         }
         if (url.includes('timezone')) {
           return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ data: { timezone: 'Europe/London' } }),
+            data: { data: { timezone: 'Europe/London' } },
           });
         }
         return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ predictions: [] }),
+          data: { predictions: [] },
         });
       });
 
@@ -395,7 +391,7 @@ describe('BirthDataForm Component', () => {
 
     it('should handle geocoding API errors gracefully', async () => {
       const user = userEvent.setup();
-      (global.fetch as any).mockRejectedValue(new Error('API Error'));
+      mockApiGet.mockRejectedValue(new Error('API Error'));
 
       renderWithQueryClient(<BirthDataForm />);
 


### PR DESCRIPTION
## Changes
- Replace raw `fetch()` calls in BirthDataForm with the existing axios `api` client
- Affects `/api/v1/location/autocomplete` and `/api/v1/location/timezone` calls
- Now properly includes CSRF tokens, auth headers, and error interceptors

## Related Issues
Closes #201

## Quality
- TypeScript check passes
- 10 lines added, 16 removed (net reduction)
- No behavior change — same API endpoints, same response handling