### PR TITLE
Fix .env.example JWT expiry to match actual config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ DATABASE_PASSWORD=password
 
 # JWT Secret
 JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
-JWT_EXPIRES_IN=7d
-JWT_REFRESH_EXPIRES_IN=30d
+JWT_EXPIRES_IN=1h
+JWT_REFRESH_EXPIRES_IN=7d
 
 # OAuth (Optional - for social login)
 GOOGLE_CLIENT_ID=


### PR DESCRIPTION
## Summary
The `.env.example` had JWT_EXPIRES_IN=7d and JWT_REFRESH_EXPIRES_IN=30d, but the actual production config (`backend/src/config/index.ts`) uses 1h and 7d respectively. Updated the example to match.

## Changes
- `JWT_EXPIRES_IN`: 7d → 1h
- `JWT_REFRESH_EXPIRES_IN`: 30d → 7d

## Quality Check
- [x] No code changes, only config example
- [x] Matches production config in `backend/src/config/index.ts`
- [x] Matches `.env.production.example` values

---
*Auto-fix by Hermes Agent — Deep Active Review*