### PR TITLE
Add missing CSRF_SECRET to .env.example + fix JWT expiry values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ DATABASE_PASSWORD=password
 
 # JWT Secret
 JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
-JWT_EXPIRES_IN=7d
-JWT_REFRESH_EXPIRES_IN=30d
+JWT_EXPIRES_IN=1h
+JWT_REFRESH_EXPIRES_IN=7d
 
 # OAuth (Optional - for social login)
 GOOGLE_CLIENT_ID=
@@ -57,3 +57,7 @@ REDIS_PORT=6379
 # Stitch MCP (for UI generation during development)
 STITCH_PROJECT_ID=
 STITCH_ENABLED=true
+
+# CSRF Protection
+# Generate with: openssl rand -base64 32
+CSRF_SECRET=your-csrf-secret-change-this-in-production


### PR DESCRIPTION
## Summary

Two fixes to `.env.example`:

### 1. Missing CSRF_SECRET (bug)
`backend/src/middleware/csrf.ts` **requires** `CSRF_SECRET` env var — the app crashes on startup without it:
```typescript
if (!process.env.CSRF_SECRET) {
  throw new Error('CSRF_SECRET environment variable is required. Set it before starting the server.');
}
```
But it was never documented in `.env.example`. New developers hitting this crash would have no guidance.

### 2. JWT expiry mismatch
`.env.example` had `JWT_EXPIRES_IN=7d` and `JWT_REFRESH_EXPIRES_IN=30d`, but the actual config defaults are `1h` and `7d` respectively. Updated to match.

## Quality Check
- [x] No code changes, only config example
- [x] CSRF_SECRET matches pattern in `.env.production.example`
- [x] JWT values now match `backend/src/config/index.ts` defaults

---
*Auto-fix by Hermes Agent — Deep Active Review*