### PR TITLE
[REVIEW FIX] Normalize PLANET_SYMBOLS keys to lowercase in astronomyEngine.service.ts

### DIFF
--- a/backend/src/__tests__/services/astronomyEngine.service.test.ts
+++ b/backend/src/__tests__/services/astronomyEngine.service.test.ts
@@ -37,9 +37,9 @@ describe('Astronomy Engine Service', () => {
       expect(PLANET_SYMBOLS.uranus).toBe('♅');
       expect(PLANET_SYMBOLS.neptune).toBe('♆');
       expect(PLANET_SYMBOLS.pluto).toBe('♇');
-      expect(PLANET_SYMBOLS.Chiron).toBe('⚷');
-      expect(PLANET_SYMBOLS.NorthNode).toBe('☊');
-      expect(PLANET_SYMBOLS.SouthNode).toBe('☋');
+      expect(PLANET_SYMBOLS.chiron).toBe('⚷');
+      expect(PLANET_SYMBOLS.northNode).toBe('☊');
+      expect(PLANET_SYMBOLS.southNode).toBe('☋');
     });
   });
 

--- a/backend/src/__tests__/services/astronomyEngine.service.test.ts
+++ b/backend/src/__tests__/services/astronomyEngine.service.test.ts
@@ -27,16 +27,16 @@ describe('Astronomy Engine Service', () => {
 
     test('should export planet symbols', () => {
       expect(PLANET_SYMBOLS).toBeDefined();
-      expect(PLANET_SYMBOLS.Sun).toBe('☉');
-      expect(PLANET_SYMBOLS.Moon).toBe('☽');
-      expect(PLANET_SYMBOLS.Mercury).toBe('☿');
-      expect(PLANET_SYMBOLS.Venus).toBe('♀');
-      expect(PLANET_SYMBOLS.Mars).toBe('♂');
-      expect(PLANET_SYMBOLS.Jupiter).toBe('♃');
-      expect(PLANET_SYMBOLS.Saturn).toBe('♄');
-      expect(PLANET_SYMBOLS.Uranus).toBe('♅');
-      expect(PLANET_SYMBOLS.Neptune).toBe('♆');
-      expect(PLANET_SYMBOLS.Pluto).toBe('♇');
+      expect(PLANET_SYMBOLS.sun).toBe('☉');
+      expect(PLANET_SYMBOLS.moon).toBe('☽');
+      expect(PLANET_SYMBOLS.mercury).toBe('☿');
+      expect(PLANET_SYMBOLS.venus).toBe('♀');
+      expect(PLANET_SYMBOLS.mars).toBe('♂');
+      expect(PLANET_SYMBOLS.jupiter).toBe('♃');
+      expect(PLANET_SYMBOLS.saturn).toBe('♄');
+      expect(PLANET_SYMBOLS.uranus).toBe('♅');
+      expect(PLANET_SYMBOLS.neptune).toBe('♆');
+      expect(PLANET_SYMBOLS.pluto).toBe('♇');
       expect(PLANET_SYMBOLS.Chiron).toBe('⚷');
       expect(PLANET_SYMBOLS.NorthNode).toBe('☊');
       expect(PLANET_SYMBOLS.SouthNode).toBe('☋');

--- a/backend/src/modules/shared/services/astronomyEngine.service.ts
+++ b/backend/src/modules/shared/services/astronomyEngine.service.ts
@@ -62,19 +62,19 @@ export type ZodiacSign = (typeof ZODIAC_SIGNS)[number];
 
 // Planet symbols for display
 export const PLANET_SYMBOLS: Record<string, string> = {
-  Sun: '☉',
-  Moon: '☽',
-  Mercury: '☿',
-  Venus: '♀',
-  Mars: '♂',
-  Jupiter: '♃',
-  Saturn: '♄',
-  Uranus: '♅',
-  Neptune: '♆',
-  Pluto: '♇',
-  Chiron: '⚷',
-  NorthNode: '☊',
-  SouthNode: '☋',
+  sun: '☉',
+  moon: '☽',
+  mercury: '☿',
+  venus: '♀',
+  mars: '♂',
+  jupiter: '♃',
+  saturn: '♄',
+  uranus: '♅',
+  neptune: '♆',
+  pluto: '♇',
+  chiron: '⚷',
+  northNode: '☊',
+  southNode: '☋',
 };
 
 export class AstronomyEngineService {


### PR DESCRIPTION
## Summary

Fixes the PLANET_SYMBOLS casing inconsistency in `astronomyEngine.service.ts` where keys were PascalCase (`Sun`, `Moon`, `Mercury`...) while all other definitions in the codebase use lowercase (`sun`, `moon`, `mercury`...).

## Changes
- `backend/src/modules/shared/services/astronomyEngine.service.ts` — Changed all 13 PLANET_SYMBOLS keys to lowercase
- `backend/src/__tests__/services/astronomyEngine.service.test.ts` — Updated 10 test assertions to use lowercase keys

## Why
`PLANET_SYMBOLS.sun` returned `undefined` when importing from astronomyEngine, while it worked correctly from swissEphemeris and shared-constants. This inconsistency caused subtle bugs when consumers expected lowercase keys (the project standard).

## Verification
- `tsc --noEmit` passes clean on backend
- `tsc --noEmit` passes clean on frontend
- Only test assertions + PLANET_SYMBOLS keys changed — no runtime logic modified

## Related Issues
- Closes #211
- Contributes to #208 (inconsistent planet key casing)
- Contributes to #178 (PLANET_SYMBOLS duplication)
