### PR TITLE
fix: wrap location routes in asyncHandler (#219)

### DIFF
--- a/backend/src/modules/shared/routes/location.routes.ts
+++ b/backend/src/modules/shared/routes/location.routes.ts
@@ -165,7 +165,7 @@ router.get('/autocomplete', asyncHandler(async (req: Request, res: Response, _ne
     logger.error('Autocomplete error:', error);
     res.status(500).json({ error: 'Location search failed' });
   }
-});
+}));
 
 /**
  * @openapi
@@ -282,7 +282,7 @@ router.get('/details/:placeId', asyncHandler(async (req: Request, res: Response,
     logger.error('Place details error:', error);
     res.status(500).json({ error: 'Failed to get place details' });
   }
-});
+}));
 
 /**
  * Fallback: Nominatim (OpenStreetMap) autocomplete
@@ -381,6 +381,6 @@ router.get('/timezone', asyncHandler(async (req: Request, res: Response, _next: 
     logger.error('Timezone lookup error:', error);
     res.status(500).json({ error: 'Timezone lookup failed' });
   }
-});
+}));
 
 export { router as locationRoutes };

--- a/backend/src/modules/shared/routes/location.routes.ts
+++ b/backend/src/modules/shared/routes/location.routes.ts
@@ -112,7 +112,7 @@ const GOOGLE_PLACES_BASE_URL = 'https://maps.googleapis.com/maps/api/place';
  * @desc    Proxy for Google Places Autocomplete
  * @access  Public (rate limited)
  */
-router.get('/autocomplete', async (req: Request, res: Response): Promise<void> => {
+router.get('/autocomplete', asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
   try {
     const validationError = validateQueryParams(req, {
       input: { minLen: 2, maxLen: 100 },
@@ -204,7 +204,7 @@ router.get('/autocomplete', async (req: Request, res: Response): Promise<void> =
  * @desc    Get place details including coordinates
  * @access  Public (rate limited)
  */
-router.get('/details/:placeId', async (req: Request, res: Response): Promise<void> => {
+router.get('/details/:placeId', asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
   try {
     const validationError = validateQueryParams(req, {
       sessiontoken: { optional: true, isString: true },
@@ -332,7 +332,7 @@ async function fetchNominatim(query: string): Promise<any[]> {
  * @desc    Get IANA timezone from lat/lon coordinates
  * @access  Public
  */
-router.get('/timezone', async (req: Request, res: Response): Promise<void> => {
+router.get('/timezone', asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
   try {
     const lat = parseFloat(req.query.lat as string);
     const lon = parseFloat(req.query.lon as string);

--- a/backend/src/modules/shared/routes/location.routes.ts
+++ b/backend/src/modules/shared/routes/location.routes.ts
@@ -6,8 +6,9 @@
  * @security API key is stored server-side, not exposed to frontend
  */
 
-import { Request, Response, Router } from 'express';
+import { NextFunction, Request, Response, Router } from 'express';
 import { logger } from '../../../utils/logger';
+import { asyncHandler } from '../../../middleware/errorHandler';
 
 // Manual validation helpers (replacing express-validator)
 function validateQueryParams(


### PR DESCRIPTION
## Summary

Fixes #219

Wraps all 3 location route async handlers in `asyncHandler` to catch unhandled promise rejections.

## Changes
- Added `asyncHandler` import from errorHandler middleware
- Added `NextFunction` to Express imports
- Wrapped `autocomplete`, `details/:placeId`, and `timezone` route handlers

Same pattern as PR #213 (AI routes).