### PR TITLE
[verified] Add missing env vars to .env.example: Stripe, OpenAI, Redis password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,18 @@ STITCH_ENABLED=true
 # CSRF Protection
 # Generate with: openssl rand -base64 32
 CSRF_SECRET=your-csrf-secret-change-this-in-production
+
+# Stripe (Required for billing)
+STRIPE_SECRET_KEY=
+STRIPE_PRO_PRICE_ID=
+STRIPE_PREMIUM_PRICE_ID=
+STRIPE_WEBHOOK_SECRET=
+
+# OpenAI (Required for AI interpretations)
+OPENAI_API_KEY=
+# OPENAI_MODEL=gpt-4-turbo-preview
+# OPENAI_MAX_TOKENS=2000
+# OPENAI_TEMPERATURE=0.7
+
+# Redis Authentication (if your Redis requires a password)
+# REDIS_PASSWORD=


### PR DESCRIPTION
## What
Adds environment variables referenced in backend config but missing from `.env.example`:

- **Stripe**: `STRIPE_SECRET_KEY`, `STRIPE_PRO_PRICE_ID`, `STRIPE_PREMIUM_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`
- **OpenAI**: `OPENAI_API_KEY`, `OPENAI_MODEL`, `OPENAI_MAX_TOKENS`, `OPENAI_TEMPERATURE`
- **Redis**: `REDIS_PASSWORD`

## Why
New developers cloning the repo get cryptic errors when these vars are unset. Stripe and OpenAI features silently fail or throw runtime errors.

## How Verified
- `tsc --noEmit` passes on both frontend and backend
- No code changes — only `.env.example` documentation

---
*Created by Hermes Agent during deep review*