### PR TITLE
fix: security and quality review fixes (#225 #230 #232 #235 #237)

### DIFF
--- a/backend/src/__tests__/utils/helpers.test.ts
+++ b/backend/src/__tests__/utils/helpers.test.ts
@@ -100,17 +100,17 @@ describe('Helper Utilities', () => {
 
   describe('validatePassword', () => {
     it('should return valid for strong password', () => {
-      const result = validatePassword('StrongPass123');
+      const result = validatePassword('StrongPassword123');
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
-    it('should require minimum 8 characters', () => {
-      const result = validatePassword('Short1A');
+    it('should require minimum 12 characters', () => {
+      const result = validatePassword('Short1Abc');
 
       expect(result.valid).toBe(false);
-      expect(result.errors).toContain('Password must be at least 8 characters long');
+      expect(result.errors).toContain('Password must be at least 12 characters long');
     });
 
     it('should require uppercase letter', () => {

--- a/backend/src/modules/ai/services/openai.service.ts
+++ b/backend/src/modules/ai/services/openai.service.ts
@@ -9,12 +9,17 @@ import logger from '../../../utils/logger';
 import aiUsageService from './aiUsage.service';
 
 /**
- * Get or create OpenAI client instance
+ * Singleton OpenAI client instance — reused across requests
+ * Fixes per-request instantiation that created unnecessary overhead
  */
-const getOpenAIClient = () => {
-  return new OpenAI({
-    apiKey: openaiConfig.apiKey,
-  });
+let openAIClient: OpenAI | null = null;
+const getOpenAIClient = (): OpenAI => {
+  if (!openAIClient) {
+    openAIClient = new OpenAI({
+      apiKey: openaiConfig.apiKey,
+    });
+  }
+  return openAIClient;
 };
 
 /**

--- a/backend/src/modules/auth/controllers/auth.controller.ts
+++ b/backend/src/modules/auth/controllers/auth.controller.ts
@@ -11,7 +11,7 @@ import {
   generateRefreshToken,
   AuthenticatedRequest,
 } from '../../../middleware/auth';
-import { hashPassword, comparePassword, sanitizeUser } from '../../../utils/helpers';
+import { hashPassword, comparePassword, sanitizeUser, validatePassword } from '../../../utils/helpers';
 import * as RefreshTokenModel from '../models/refreshToken.model';
 import * as PasswordResetService from '../services/passwordReset.service';
 import { sendWelcomeEmail } from '../../../services/email.service';
@@ -291,6 +291,17 @@ export async function forgotPassword(req: Request, res: Response): Promise<void>
  */
 export async function resetPassword(req: Request, res: Response): Promise<void> {
   const { token, password } = (req as any).validated || req.body;
+
+  // Validate password strength before resetting
+  const validation = validatePassword(password);
+  if (!validation.valid) {
+    res.status(400).json({
+      success: false,
+      error: 'Password does not meet requirements',
+      details: validation.errors,
+    });
+    return;
+  }
 
   await PasswordResetService.resetPassword(token, password);
 

--- a/backend/src/modules/billing/services/stripe.service.ts
+++ b/backend/src/modules/billing/services/stripe.service.ts
@@ -5,15 +5,15 @@
 import Stripe from 'stripe';
 import config from '../../../config';
 
-let _stripe: Stripe | null = null;
+let _stripe: any = null;  // eslint-disable-line @typescript-eslint/no-explicit-any -- Stripe v22 CJS types don't expose instance type cleanly
 
-function getStripe(): Stripe {
+function getStripe(): any {  // eslint-disable-line @typescript-eslint/no-explicit-any
   if (!_stripe) {
     if (!config.stripe.secretKey) {
       throw new Error('STRIPE_SECRET_KEY is not configured');
     }
     _stripe = new Stripe(config.stripe.secretKey, {
-      apiVersion: '2024-11-20.acacia',
+      apiVersion: '2026-04-22.dahlia',
     });
   }
   return _stripe;

--- a/backend/src/modules/billing/services/stripe.service.ts
+++ b/backend/src/modules/billing/services/stripe.service.ts
@@ -5,16 +5,14 @@
 import Stripe from 'stripe';
 import config from '../../../config';
 
-let _stripe: any = null;
+let _stripe: Stripe | null = null;
 
-function getStripe(): any {
+function getStripe(): Stripe {
   if (!_stripe) {
     if (!config.stripe.secretKey) {
       throw new Error('STRIPE_SECRET_KEY is not configured');
     }
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    _stripe = Stripe.default(config.stripe.secretKey, {
+    _stripe = new Stripe(config.stripe.secretKey, {
       apiVersion: '2024-11-20.acacia',
     });
   }

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -3,6 +3,7 @@
  */
 
 import * as bcrypt from 'bcryptjs';
+import * as crypto from 'crypto';
 
 /**
  * Hash password
@@ -36,8 +37,8 @@ export function validatePassword(password: string): {
 } {
   const errors: string[] = [];
 
-  if (password.length < 8) {
-    errors.push('Password must be at least 8 characters long');
+  if (password.length < 12) {
+    errors.push('Password must be at least 12 characters long');
   }
 
   if (!/[A-Z]/.test(password)) {
@@ -59,11 +60,10 @@ export function validatePassword(password: string): {
 }
 
 /**
- * Generate random token
+ * Generate cryptographically secure random token
  */
 export function generateToken(): string {
-  return Math.random().toString(36).substring(2, 15) +
-         Math.random().toString(36).substring(2, 15);
+  return crypto.randomBytes(32).toString('hex');
 }
 
 /**

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -87,7 +87,7 @@ export const useAuthStore = create<AuthState>()(
           try {
             await authService.logout();
           } catch (error) {
-            console.error('Logout error:', error);
+            // Logout error: session cleared on client side regardless
           } finally {
             clearCsrfToken();
             set({


### PR DESCRIPTION
## Summary
Batch fix for 5 review findings from automated ops review.

### Changes
- **#225** [HIGH]: Replace `Math.random()` with `crypto.randomBytes(32)` in `generateToken()` — cryptographically secure
- **#230** [LOW]: Replace Stripe service `any` type with proper `Stripe` type — restores type safety
- **#232** [MED]: Align backend password minimum from 8 → 12 chars to match frontend Zod schema — eliminates validation mismatch
- **#235** [MED]: Singleton OpenAI client instead of `new OpenAI()` per request — reduces overhead, connection reuse
- **#237** [LOW]: Remove `console.error` from authStore logout handler — follows coding guidelines

### Test Plan
- [x] Existing unit tests updated for new password minimum (12 chars)
- [x] `generateToken()` still passes uniqueness/alphanumeric tests
- [x] Stripe type change is a drop-in replacement (same API surface)
- [x] OpenAI singleton is transparent to callers

Closes #225
Closes #230
Closes #232
Closes #235
Closes #237