### PR TITLE
[codex] Allow Stripe in content security policy

### DIFF
--- a/backend/src/__tests__/server/stripe-csp.test.ts
+++ b/backend/src/__tests__/server/stripe-csp.test.ts
@@ -1,0 +1,19 @@
+import request from 'supertest';
+import app from '../../server';
+
+describe('Stripe Content Security Policy', () => {
+  it('allows Stripe Checkout and Stripe.js in CSP directives', async () => {
+    const response = await request(app).get('/health');
+    const cspHeader = response.headers['content-security-policy'];
+
+    expect(cspHeader).toBeDefined();
+    expect(cspHeader).toContain('script-src');
+    expect(cspHeader).toContain('https://js.stripe.com');
+    expect(cspHeader).toContain('frame-src');
+    expect(cspHeader).toContain('https://checkout.stripe.com');
+    expect(cspHeader).toContain('connect-src');
+    expect(cspHeader).toContain('https://api.stripe.com');
+    expect(cspHeader).toContain('img-src');
+    expect(cspHeader).toContain('https://*.stripe.com');
+  });
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -25,6 +25,12 @@ import apiRouter from './api';
 const app: Application = express();
 const PORT = process.env.PORT || 3001;
 const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
+const STRIPE_CSP = {
+  scriptSrc: ['https://js.stripe.com'],
+  frameSrc: ['https://js.stripe.com', 'https://checkout.stripe.com'],
+  connectSrc: ['https://api.stripe.com'],
+  imgSrc: ['https://*.stripe.com'],
+};
 
 // ============================================
 // Security Middleware
@@ -36,17 +42,21 @@ app.use(helmet({
     directives: {
       defaultSrc: ["'self'"],
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
-      scriptSrc: process.env.NODE_ENV === 'development' ? ["'self'", "'unsafe-eval'"] : ["'self'"],
-      imgSrc: ["'self'", "data:", "https:"],
+      scriptSrc:
+        process.env.NODE_ENV === 'development'
+          ? ["'self'", "'unsafe-eval'", ...STRIPE_CSP.scriptSrc]
+          : ["'self'", ...STRIPE_CSP.scriptSrc],
+      imgSrc: ["'self'", "data:", "https:", ...STRIPE_CSP.imgSrc],
       connectSrc: [
         "'self'",
         "https://fonts.googleapis.com",
         "https://fonts.gstatic.com",
+        ...STRIPE_CSP.connectSrc,
       ],
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       objectSrc: ["'none'"],
       mediaSrc: ["'self'"],
-      frameSrc: ["'self'"],
+      frameSrc: ["'self'", ...STRIPE_CSP.frameSrc],
     },
   },
   crossOriginEmbedderPolicy: false,


### PR DESCRIPTION
## Summary
- Allow Stripe.js, Stripe Checkout frames, Stripe API calls, and Stripe-hosted payment assets in the Helmet CSP.
- Keep the existing development `unsafe-eval` behavior intact while adding Stripe script sources in both environments.
- Add a focused server regression test that asserts the CSP header contains the required Stripe directives.

Refs #250.

## Validation
- `PUPPETEER_SKIP_DOWNLOAD=1 npm ci` using bundled Node/Python after native `swisseph` failed under Homebrew Python 3.14 without `distutils`
- `npm run test --workspace=backend -- --runTestsByPath src/__tests__/server/stripe-csp.test.ts --runInBand`
- `npm run build --workspace=backend`
- `git diff --check`
