### PR TITLE
fix(security): add validateParams for path parameters in chart, analysis, notification routes

### DIFF
--- a/backend/src/modules/analysis/routes/analysis.routes.ts
+++ b/backend/src/modules/analysis/routes/analysis.routes.ts
@@ -5,7 +5,13 @@
 import { Router } from 'express';
 import { authenticate, AuthenticatedRequest } from '../../../middleware/auth';
 import { asyncHandler } from '../../../middleware/errorHandler';
+import { validateParams } from '../../../utils/validators';
+import { z } from 'zod';
 import * as AnalysisController from '../controllers/analysis.controller';
+
+const chartIdParamSchema = z.object({
+  chartId: z.string().uuid(),
+});
 
 const router = Router();
 
@@ -40,6 +46,7 @@ router.use(authenticate);
  */
 router.get(
   '/:chartId',
+  validateParams(chartIdParamSchema),
   asyncHandler(async (req, res) => {
     await AnalysisController.getPersonalityAnalysis(req as AuthenticatedRequest, res);
   }),
@@ -73,6 +80,7 @@ router.get(
  */
 router.get(
   '/:chartId/aspects',
+  validateParams(chartIdParamSchema),
   asyncHandler(async (req, res) => {
     await AnalysisController.getAspectAnalysis(req as AuthenticatedRequest, res);
   }),
@@ -106,6 +114,7 @@ router.get(
  */
 router.get(
   '/:chartId/patterns',
+  validateParams(chartIdParamSchema),
   asyncHandler(async (req, res) => {
     await AnalysisController.getAspectPatterns(req as AuthenticatedRequest, res);
   }),
@@ -139,6 +148,7 @@ router.get(
  */
 router.get(
   '/:chartId/planets',
+  validateParams(chartIdParamSchema),
   asyncHandler(async (req, res) => {
     await AnalysisController.getPlanetsInSigns(req as AuthenticatedRequest, res);
   }),
@@ -172,6 +182,7 @@ router.get(
  */
 router.get(
   '/:chartId/houses',
+  validateParams(chartIdParamSchema),
   asyncHandler(async (req, res) => {
     await AnalysisController.getHousesAnalysis(req as AuthenticatedRequest, res);
   }),

--- a/backend/src/modules/charts/routes/chart.routes.ts
+++ b/backend/src/modules/charts/routes/chart.routes.ts
@@ -8,6 +8,7 @@ import { asyncHandler } from '../../../middleware/errorHandler';
 import { enforceChartLimit } from '../../../middleware/planEnforcement';
 import { chartCreationRateLimiter } from '../../../middleware/rateLimiter';
 import { validateRequest } from '../../../middleware/validateRequest';
+import { validateParams, uuidParamSchema } from '../../../utils/validators';
 import {
   CreateNatalChartSchema,
   UpdateChartSchema,
@@ -96,6 +97,7 @@ router.get(
  */
 router.get(
   '/:id',
+  validateParams(uuidParamSchema),
   asyncHandler(async (req, res) => {
     await ChartController.getChart(req as AuthenticatedRequest, res);
   }),
@@ -123,6 +125,7 @@ router.get(
  */
 router.put(
   '/:id',
+  validateParams(uuidParamSchema),
   validateRequest(UpdateChartSchema),
   asyncHandler(async (req, res) => {
     await ChartController.updateChart(req as AuthenticatedRequest, res);
@@ -151,6 +154,7 @@ router.put(
  */
 router.delete(
   '/:id',
+  validateParams(uuidParamSchema),
   asyncHandler(async (req, res) => {
     await ChartController.deleteChart(req as AuthenticatedRequest, res);
   }),
@@ -178,6 +182,7 @@ router.delete(
  */
 router.post(
   '/:id/calculate',
+  validateParams(uuidParamSchema),
   asyncHandler(async (req, res) => {
     await ChartController.calculateChart(req as AuthenticatedRequest, res);
   }),

--- a/backend/src/modules/notifications/routes/pushNotification.routes.ts
+++ b/backend/src/modules/notifications/routes/pushNotification.routes.ts
@@ -11,6 +11,12 @@ import {
   getVapidPublicKey,
 } from '../controllers/pushNotification.controller';
 import { authenticate } from '../../../middleware/auth';
+import { validateParams } from '../../../utils/validators';
+import { z } from 'zod';
+
+const subscriptionIdParamSchema = z.object({
+  subscriptionId: z.string().uuid(),
+});
 
 const router = express.Router();
 
@@ -82,7 +88,7 @@ router.post('/subscribe', saveSubscription);
  *       404:
  *         description: Subscription not found
  */
-router.delete('/subscribe/:subscriptionId', deleteSubscription);
+router.delete('/subscribe/:subscriptionId', validateParams(subscriptionIdParamSchema), deleteSubscription);
 
 /**
  * @route   GET /api/v1/notifications/subscriptions


### PR DESCRIPTION
## Summary
Add `validateParams` middleware to route handlers that accept path parameters, ensuring UUID format validation before reaching controllers.

### Changes
- **Chart routes** (`chart.routes.ts`): Add `validateParams(uuidParamSchema)` for `:id` on GET, PUT, DELETE, and POST `/:id/calculate`
- **Analysis routes** (`analysis.routes.ts`): Add `validateParams(chartIdParamSchema)` for `:chartId` on all 5 endpoints (personality, aspects, patterns, planets, houses)
- **Push notification routes** (`pushNotification.routes.ts`): Add `validateParams(subscriptionIdParamSchema)` for `:subscriptionId` on DELETE

### Security Impact
Without param validation, malformed or injection-style path parameters reach controllers directly. Now they're validated as UUID format at the middleware layer (400 response for invalid input).

### Testing
- TypeScript compilation: clean (`npx tsc --noEmit`)
- Backend tests: 185/185 pass (chart + analysis + notification suites)

Closes #297
Closes #298
Closes #299