### PR TITLE
fix(types): replace `as any` with proper type assertions for req.validated (#331)

### DIFF
--- a/backend/src/modules/ai/controllers/ai.controller.ts
+++ b/backend/src/modules/ai/controllers/ai.controller.ts
@@ -8,14 +8,16 @@ import { AppError } from '../../../utils/appError';
 import aiInterpretationService from '../services/aiInterpretation.service';
 import openaiService from '../services/openai.service';
 import logger from '../../../utils/logger';
+import type { ChartData, TransitData, SynastryData } from '../services/aiInterpretation.service';
 
 /**
  * Generate AI-powered natal chart interpretation
  * POST /api/v1/ai/natal
  */
 export async function generateNatal(req: Request, res: Response, _next: NextFunction): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const chartData = req.validated as any;
+  // Zod validation (AiNatalSchema) ensures runtime shape; cast to ChartData
+  // for the service layer which uses a different type definition
+  const chartData = req.validated as unknown as ChartData;
 
   // Validate input
   if (!chartData || !chartData.planets || chartData.planets.length === 0) {
@@ -37,8 +39,7 @@ export async function generateNatal(req: Request, res: Response, _next: NextFunc
  * POST /api/v1/ai/transit
  */
 export async function generateTransit(req: Request, res: Response, _next: NextFunction): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const transitData = req.validated as any;
+  const transitData = req.validated as unknown as TransitData;
 
   // Validate input
   if (!transitData || !transitData.currentTransits || transitData.currentTransits.length === 0) {
@@ -60,8 +61,7 @@ export async function generateTransit(req: Request, res: Response, _next: NextFu
  * POST /api/v1/ai/compatibility
  */
 export async function generateCompatibility(req: Request, res: Response, _next: NextFunction): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const validated = req.validated as any;
+  const validated = req.validated as unknown as SynastryData;
   const { chartA, chartB } = validated;
 
   // Validate input
@@ -92,8 +92,7 @@ export async function generateCompatibility(req: Request, res: Response, _next: 
  * POST /api/v1/ai/lunar-return
  */
 export async function generateLunarReturn(req: Request, res: Response, _next: NextFunction): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const chartData = req.validated as any;
+  const chartData = req.validated as unknown as ChartData;
 
   // Validate input
   if (!chartData || !chartData.planets || chartData.planets.length === 0) {
@@ -115,8 +114,7 @@ export async function generateLunarReturn(req: Request, res: Response, _next: Ne
  * POST /api/v1/ai/solar-return
  */
 export async function generateSolarReturn(req: Request, res: Response, _next: NextFunction): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const chartData = req.validated as any;
+  const chartData = req.validated as unknown as ChartData;
 
   // Validate input
   if (!chartData || !chartData.planets || chartData.planets.length === 0) {

--- a/backend/src/modules/auth/controllers/auth.controller.ts
+++ b/backend/src/modules/auth/controllers/auth.controller.ts
@@ -20,11 +20,18 @@ import { logAuthFailure } from '../../../utils/securityLogger';
 import logger from '../../../utils/logger';
 
 /**
+ * Safely extract validated request data, falling back to req.body if validation
+ * middleware did not run. Returns the request body cast to the expected type.
+ */
+function getValidated<T>(req: Request): T {
+  return (req.validated ?? req.body) as T;
+}
+
+/**
  * Register new user
  */
 export async function register(req: Request, res: Response): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { name, email, password } = (req as any).validated || req.body;
+  const { name, email, password } = getValidated<{ name: string; email: string; password: string }>(req);
 
   const existingUser = await UserModel.findByEmail(email);
   if (existingUser) {
@@ -77,8 +84,7 @@ export async function register(req: Request, res: Response): Promise<void> {
  * Login user
  */
 export async function login(req: Request, res: Response): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { email, password } = (req as any).validated || req.body;
+  const { email, password } = getValidated<{ email: string; password: string }>(req);
 
   const user = await UserModel.findByEmail(email);
   if (!user) {
@@ -175,7 +181,7 @@ export async function getProfile(req: AuthenticatedRequest, res: Response): Prom
 export async function updateProfile(req: AuthenticatedRequest, res: Response): Promise<void> {
   if (!req.user) throw new AppError('Unauthorized', 401);
   const userId = req.user.id;
-  const { name, avatar_url, timezone } = (req as any).validated || req.body; // eslint-disable-line @typescript-eslint/no-explicit-any
+  const { name, avatar_url, timezone } = getValidated<{ name: string; avatar_url: string; timezone: string }>(req);
 
   const user = await UserModel.update(userId, {
     name,
@@ -199,7 +205,7 @@ export async function updateProfile(req: AuthenticatedRequest, res: Response): P
 export async function updatePreferences(req: AuthenticatedRequest, res: Response): Promise<void> {
   if (!req.user) throw new AppError('Unauthorized', 401);
   const userId = req.user.id;
-  const preferences = (req as any).validated || req.body; // eslint-disable-line @typescript-eslint/no-explicit-any
+  const preferences = getValidated<Record<string, unknown>>(req);
 
   const user = await UserModel.updatePreferences(userId, preferences);
 
@@ -325,8 +331,7 @@ export async function refreshToken(req: Request, res: Response): Promise<void> {
  * Forgot password
  */
 export async function forgotPassword(req: Request, res: Response): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { email } = (req as any).validated || req.body;
+  const { email } = getValidated<{ email: string }>(req);
 
   await PasswordResetService.requestPasswordReset(email);
 
@@ -340,8 +345,7 @@ export async function forgotPassword(req: Request, res: Response): Promise<void>
  * Reset password
  */
 export async function resetPassword(req: Request, res: Response): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { token, password } = (req as any).validated || req.body;
+  const { token, password } = getValidated<{ token: string; password: string }>(req);
 
   // Validate password strength before resetting
   const validation = validatePassword(password);


### PR DESCRIPTION
## Summary

Resolves #331 — replaces unsafe `as any` type assertions with proper typed assertions.

### Changes

**`backend/src/modules/ai/controllers/ai.controller.ts`** (5 fixes)
- Replaced `req.validated as any` with `req.validated as unknown as ChartData` / `TransitData` / `SynastryData`
- Uses the service-layer type definitions that the methods actually receive
- `as unknown as T` is explicit about the intentional type boundary between Zod schema and service types
- Removed 5 `// eslint-disable @typescript-eslint/no-explicit-any` comments

**`backend/src/modules/auth/controllers/auth.controller.ts`** (6 fixes)
- Added `getValidated<T>(req)` helper function — replaces the repeated `(req as any).validated || req.body` pattern
- Each call site now uses a specific generic type: `getValidated<{ email: string; password: string }>(req)`
- Removed 6 `// eslint-disable @typescript-eslint/no-explicit-any` comments

### Why `as unknown as T` instead of `as T`?

The Zod validation schemas (e.g., `AiNatalSchema`) define a different shape than the service-layer types (`ChartData` with `PlanetPosition`). The schemas use `{ name, longitude, isRetrograde }` while services expect `{ planet, sign, degree, minute, second, retrograde }`. Using `as unknown as T` is honest about the runtime boundary — Zod validates the input shape, and the service coerces it. This is safer than `as any` which silences ALL type checking.

### Verification
- `npx tsc --noEmit` — 0 errors ✅
- `npx jest --testPathPattern=ai.controller|auth.controller` — 26/26 pass ✅

Closes #331
