### PR TITLE
fix(docs,a11y): add Helmet titles, move tests, update counts (#328 #334 #336)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Full-stack astrology platform: natal charts with interactive chart wheel, AI-pow
 
 **Current Version:** v1.0.0
 **CI Status:** All pipeline jobs green (backend, frontend, live, e2e, visual, integration, BDD, accessibility, verify-build) + mutation testing
-**Tests:** 1,439 backend (Jest) + 3,800 frontend (Vitest) = 5,239 total
+**Tests:** 1,514 backend (Jest) + 3,800 frontend (Vitest) = 5,314 total
 
 ### What's Done
 - **109 API endpoints** across 16 backend modules

--- a/frontend/src/__tests__/pages/ForgotPasswordPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgotPasswordPage.test.tsx
@@ -15,6 +15,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
 import { createElement } from 'react';
 import { createElement as h } from 'react';
 
@@ -38,9 +39,13 @@ import { authService } from '../../services/auth.service';
 const renderForgotPasswordPage = () => {
   return render(
     createElement(
-      MemoryRouter,
+      HelmetProvider,
       null,
-      createElement(ForgotPasswordPage),
+      createElement(
+        MemoryRouter,
+        null,
+        createElement(ForgotPasswordPage),
+      ),
     ),
   );
 };

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -11,6 +11,7 @@ import type { PersonalityAnalysisData, PlanetSignInterpretation, HouseInterpreta
 import { useChartAnalysis } from '../hooks';
 import { getErrorMessage } from '../utils/errorHandling';
 
+import { Helmet } from 'react-helmet-async';
 /**
  * Map backend interpretation to frontend component shape.
  * The backend returns full PlanetInSignInterpretation objects (keywords,
@@ -148,6 +149,10 @@ export function AnalysisPage() {
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Personality Analysis — AstroVerse</title>
+        <meta name="description" content="Detailed personality analysis of your natal chart with AI-enhanced interpretations." />
+      </Helmet>
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2 gradient-text">Personality Analysis</h1>
       </div>

--- a/frontend/src/pages/BlogPage.tsx
+++ b/frontend/src/pages/BlogPage.tsx
@@ -9,6 +9,7 @@ import { useBlogStore } from '../stores/blogStore';
 import type { BlogPost } from '../services/blog.service';
 import { APP_LOCALE } from '../utils/constants';
 
+import { Helmet } from 'react-helmet-async';
 const ADMIN_EMAILS: string[] = String(import.meta.env.VITE_ADMIN_EMAILS ?? '')
   .split(',')
   .map((e: string) => e.trim().toLowerCase())
@@ -149,6 +150,10 @@ export default function BlogPage() {
 
   return (
     <div className="min-h-screen bg-cosmic-page">
+      <Helmet>
+        <title>Blog — AstroVerse</title>
+        <meta name="description" content="Astrology articles, insights, and cosmic updates." />
+      </Helmet>
       {/* Header */}
       <div className="border-b border-white/5 bg-[var(--color-bg-card-solid,#141627)]">
         <div className="max-w-5xl mx-auto px-4 py-12 sm:px-6 lg:px-8">

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,5 +1,6 @@
 import { CalendarPageShell } from '../components/CalendarPageShell';
 
+import { Helmet } from 'react-helmet-async';
 export default function CalendarPage() {
   return (
     <CalendarPageShell

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,11 +1,18 @@
 import { CalendarPageShell } from '../components/CalendarPageShell';
 
 import { Helmet } from 'react-helmet-async';
+
 export default function CalendarPage() {
   return (
-    <CalendarPageShell
+    <>
+      <Helmet>
+        <title>Astrological Calendar — AstroVerse</title>
+        <meta name="description" content="Track moon phases, retrogrades, and cosmic events." />
+      </Helmet>
+      <CalendarPageShell
       title="Astrological Calendar"
       description="Track moon phases, retrogrades, and cosmic events"
     />
+    </>
   );
 }

--- a/frontend/src/pages/ChartCreatePage.tsx
+++ b/frontend/src/pages/ChartCreatePage.tsx
@@ -8,6 +8,7 @@
 import { useNavigate } from 'react-router-dom';
 import { AppLayout, BirthDataForm } from '../components';
 
+import { Helmet } from 'react-helmet-async';
 export default function ChartCreatePage() {
   const navigate = useNavigate();
 
@@ -17,6 +18,10 @@ export default function ChartCreatePage() {
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Create Chart — AstroVerse</title>
+        <meta name="description" content="Create a new natal chart by entering your birth details." />
+      </Helmet>
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2 gradient-text">Create Natal Chart</h1>
         <p className="text-slate-200">

--- a/frontend/src/pages/ChartCreationWizardPage.tsx
+++ b/frontend/src/pages/ChartCreationWizardPage.tsx
@@ -20,6 +20,7 @@ import { Checkbox } from '../components/ui/Checkbox';
 import { CustomDatePicker } from '../components/form/CustomDatePicker';
 import { AppLayout } from '../components';
 
+import { Helmet } from 'react-helmet-async';
 type WizardStep = 1 | 2 | 3;
 
 interface PersonalDetails {
@@ -195,6 +196,10 @@ export const ChartCreationWizardPage: React.FC = () => {
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Chart Wizard — AstroVerse</title>
+        <meta name="description" content="Step-by-step guided natal chart creation wizard." />
+      </Helmet>
       {/* Background Effects */}
       <div className="fixed inset-0 pointer-events-none z-0">
         <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] bg-primary/10 rounded-full blur-[100px]" />

--- a/frontend/src/pages/ChartViewPage.tsx
+++ b/frontend/src/pages/ChartViewPage.tsx
@@ -11,6 +11,7 @@ import { useChartStore } from '../stores/chartStore';
 import NatalAspectRow from '../components/astrology/NatalAspectRow';
 import type { ChartData, HouseCusp, Aspect, PlanetData, PlanetPosition } from '../types/chart.types';
 
+import { Helmet } from 'react-helmet-async';
 const ZODIAC_SIGNS = ['aries','taurus','gemini','cancer','leo','virgo','libra','scorpio','sagittarius','capricorn','aquarius','pisces'];
 
 function signFromDegree(deg: number): string {
@@ -173,6 +174,10 @@ export default function ChartViewPage() {
   if (!chartId) {
     return (
       <AppLayout>
+      <Helmet>
+        <title>View Chart — AstroVerse</title>
+        <meta name="description" content="View and explore your natal chart with detailed planetary positions." />
+      </Helmet>
         <EmptyState
           icon="📊"
           title="No chart specified"

--- a/frontend/src/pages/EphemerisPage.tsx
+++ b/frontend/src/pages/EphemerisPage.tsx
@@ -13,6 +13,7 @@ import { getErrorMessage } from '../utils/errorHandling';
 import { PLANET_SYMBOLS_LOWER } from '../utils/astrology/planetPosition';
 import { APP_LOCALE } from '../utils/constants';
 
+import { Helmet } from 'react-helmet-async';
 // Aspect label mapping
 const ASPECT_LABELS: Record<string, string> = {
   conjunction: 'Conjunction',
@@ -94,6 +95,10 @@ const EphemerisPage: React.FC = () => {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-cosmic-page p-4 sm:p-6">
+      <Helmet>
+        <title>Ephemeris — AstroVerse</title>
+        <meta name="description" content="Planetary ephemeris data and current celestial positions." />
+      </Helmet>
         <div className="flex items-center mb-4">
           <button type="button"
             onClick={() => navigate('/dashboard')}

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -5,6 +5,7 @@ import { authService } from '../services/auth.service';
 import { getErrorMessage } from '../utils/errorHandling';
 
 import { Helmet } from 'react-helmet-async';
+
 export function ForgotPasswordPage() {
   const [email, setEmail] = useState('');
   const [submitted, setSubmitted] = useState(false);
@@ -27,6 +28,9 @@ export function ForgotPasswordPage() {
 
   return (
     <PublicPageLayout>
+      <Helmet>
+        <title>Reset Password — AstroVerse</title>
+      </Helmet>
       <div className="min-h-[80vh] flex items-center justify-center px-4">
         <div className="w-full max-w-md">
           <div className="text-center mb-8">

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -4,6 +4,7 @@ import { PublicPageLayout } from '../components/PublicPageLayout';
 import { authService } from '../services/auth.service';
 import { getErrorMessage } from '../utils/errorHandling';
 
+import { Helmet } from 'react-helmet-async';
 export function ForgotPasswordPage() {
   const [email, setEmail] = useState('');
   const [submitted, setSubmitted] = useState(false);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -7,11 +7,16 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
+import { Helmet } from 'react-helmet-async';
 export default function HomePage() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
     <div className="bg-cosmic-page text-slate-100 font-sans antialiased overflow-x-hidden">
+      <Helmet>
+        <title>AstroVerse — Your Cosmic Companion</title>
+        <meta name="description" content="Astrology SaaS platform for natal charts, transits, and cosmic insights." />
+      </Helmet>
       {/* Skip to content */}
       <a href="#main-content" className="skip-link">Skip to main content</a>
 

--- a/frontend/src/pages/LunarReturnsPage.tsx
+++ b/frontend/src/pages/LunarReturnsPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../components';
 import { LunarReturnChart, SavedLunarReturn } from '../services/lunarReturn.api';
 
+import { Helmet } from 'react-helmet-async';
 type ViewMode = 'dashboard' | 'chart' | 'forecast' | 'history';
 
 const LunarReturnsPage: React.FC = () => {
@@ -102,6 +103,10 @@ const LunarReturnsPage: React.FC = () => {
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Lunar Returns — AstroVerse</title>
+        <meta name="description" content="Calculate and explore your lunar return charts." />
+      </Helmet>
       <div className="mb-6 sm:mb-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl sm:text-3xl font-bold mb-2 gradient-text">Lunar Returns</h1>

--- a/frontend/src/pages/MoonCalendarPage.tsx
+++ b/frontend/src/pages/MoonCalendarPage.tsx
@@ -1,12 +1,19 @@
 import { CalendarPageShell } from '../components/CalendarPageShell';
 
 import { Helmet } from 'react-helmet-async';
+
 export default function MoonCalendarPage() {
   return (
-    <CalendarPageShell
+    <>
+      <Helmet>
+        <title>Moon Calendar — AstroVerse</title>
+        <meta name="description" content="Track lunar phases, eclipses, and moon-related events." />
+      </Helmet>
+      <CalendarPageShell
       title="Moon Calendar"
       description="Track lunar phases, eclipses, and moon-related events"
       moonOnly
     />
+    </>
   );
 }

--- a/frontend/src/pages/MoonCalendarPage.tsx
+++ b/frontend/src/pages/MoonCalendarPage.tsx
@@ -1,5 +1,6 @@
 import { CalendarPageShell } from '../components/CalendarPageShell';
 
+import { Helmet } from 'react-helmet-async';
 export default function MoonCalendarPage() {
   return (
     <CalendarPageShell

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { PublicPageLayout } from '../components/PublicPageLayout';
 
+import { Helmet } from 'react-helmet-async';
 export function NotFoundPage() {
   return (
     <PublicPageLayout>

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -2,9 +2,13 @@ import { Link } from 'react-router-dom';
 import { PublicPageLayout } from '../components/PublicPageLayout';
 
 import { Helmet } from 'react-helmet-async';
+
 export function NotFoundPage() {
   return (
     <PublicPageLayout>
+      <Helmet>
+        <title>Page Not Found — AstroVerse</title>
+      </Helmet>
       <div className="min-h-[80vh] flex items-center justify-center px-4">
         <div className="text-center">
           <span className="material-symbols-outlined text-primary mb-6 text-8xl" aria-hidden="true">

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -7,12 +7,17 @@ import { useAuth } from '../hooks';
 import { getErrorMessage } from '../utils/errorHandling';
 import { useNavigate } from 'react-router-dom';
 
+import { Helmet } from 'react-helmet-async';
 export default function ProfilePage() {
   const { user, isLoading, error } = useAuth();
   const navigate = useNavigate();
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Profile — AstroVerse</title>
+        <meta name="description" content="Manage your AstroVerse account profile and preferences." />
+      </Helmet>
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2 gradient-text">My Profile</h1>
       </div>

--- a/frontend/src/pages/RegisterPageNew.tsx
+++ b/frontend/src/pages/RegisterPageNew.tsx
@@ -10,6 +10,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../hooks';
 import { useNotificationStore } from '../stores/notificationStore';
 
+import { Helmet } from 'react-helmet-async';
 // Password strength calculator
 const calculatePasswordStrength = (
   password: string,
@@ -82,6 +83,10 @@ export default function RegisterPageNew() {
 
   return (
     <div className="font-display bg-gradient-to-br from-cosmic-page to-cosmic-card text-slate-100 min-h-screen flex flex-col selection:bg-primary selection:text-white overflow-x-hidden">
+      <Helmet>
+        <title>Register — AstroVerse</title>
+        <meta name="description" content="Create your AstroVerse account to start exploring the cosmos." />
+      </Helmet>
       <div className="flex flex-col lg:flex-row min-h-screen w-full">
         {/* Left Panel: Brand & Features */}
         <div

--- a/frontend/src/pages/RetrogradePage.tsx
+++ b/frontend/src/pages/RetrogradePage.tsx
@@ -15,6 +15,7 @@ import { useCharts, useTransitCalendar } from '../hooks';
 import type { TransitReading } from '../services/transit.service';
 import { getErrorMessage } from '../utils/errorHandling';
 
+import { Helmet } from 'react-helmet-async';
 /**
  * Outer planets that can retrograde (beyond the Sun/Moon which never do).
  */
@@ -90,6 +91,10 @@ export default function RetrogradePage() {
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Retrogrades — AstroVerse</title>
+        <meta name="description" content="Track planetary retrogrades and their effects on your chart." />
+      </Helmet>
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2">Retrograde Tracker</h1>
         <p className="text-slate-200">

--- a/frontend/src/pages/SavedChartsGalleryPage.tsx
+++ b/frontend/src/pages/SavedChartsGalleryPage.tsx
@@ -19,6 +19,7 @@ import { AppLayout, EmptyState } from '../components';
 import { useNotificationStore } from '../stores/notificationStore';
 import type { Chart } from '../services/api.types';
 
+import { Helmet } from 'react-helmet-async';
 type ViewMode = 'grid' | 'list';
 type SortBy = 'dateAdded' | 'name' | 'sign';
 type FilterFolder = 'all' | 'personal' | 'clients' | 'relationships' | 'favorites';
@@ -196,6 +197,10 @@ export const SavedChartsGalleryPage: React.FC = () => {
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Saved Charts — AstroVerse</title>
+        <meta name="description" content="Browse and manage your saved natal charts gallery." />
+      </Helmet>
       <div className="pb-12 max-w-[1440px] mx-auto px-6 lg:px-12 flex gap-8">
         {/* Sidebar */}
         <aside className="hidden lg:flex flex-col w-64 gap-8 sticky top-24 h-fit">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { AppLayout } from '../components/AppLayout';
 import { useAuth } from '../hooks';
 
+import { Helmet } from 'react-helmet-async';
 interface ToggleSwitchProps {
   enabled: boolean;
   onChange: (value: boolean) => void;
@@ -126,6 +127,10 @@ export default function SettingsPage() {
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Settings — AstroVerse</title>
+        <meta name="description" content="Configure your AstroVerse account settings and preferences." />
+      </Helmet>
       {/* Page Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2 gradient-text">Settings</h1>

--- a/frontend/src/pages/SolarReturnsPage.tsx
+++ b/frontend/src/pages/SolarReturnsPage.tsx
@@ -8,6 +8,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import api from '../services/api';
 import { SolarReturnDashboard, SolarReturnChart, SolarReturnInterpretation, RelocationCalculator, BirthdaySharing, AppLayout } from '../components';
 
+import { Helmet } from 'react-helmet-async';
 interface RelocationLocation {
   name: string;
   latitude: number;
@@ -170,6 +171,10 @@ export const SolarReturnsPage: React.FC = () => {
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Solar Returns — AstroVerse</title>
+        <meta name="description" content="Calculate and explore your solar return charts." />
+      </Helmet>
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2 gradient-text">Solar Returns</h1>
         <p className="text-slate-200">

--- a/frontend/src/pages/StaticPage.tsx
+++ b/frontend/src/pages/StaticPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { PublicPageLayout } from '../components/PublicPageLayout';
 import { staticPages } from '../data/staticPages';
 
+import { Helmet } from 'react-helmet-async';
 interface StaticPageProps {
   pageKey: string;
 }

--- a/frontend/src/pages/StaticPage.tsx
+++ b/frontend/src/pages/StaticPage.tsx
@@ -4,6 +4,7 @@ import { PublicPageLayout } from '../components/PublicPageLayout';
 import { staticPages } from '../data/staticPages';
 
 import { Helmet } from 'react-helmet-async';
+
 interface StaticPageProps {
   pageKey: string;
 }
@@ -34,6 +35,10 @@ const StaticPage: React.FC<StaticPageProps> = ({ pageKey }) => {
 
   return (
     <PublicPageLayout hideAuthLinks>
+      <Helmet>
+        <title>{pageData.title} — AstroVerse</title>
+        <meta name="description" content={pageData.description} />
+      </Helmet>
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
         <header className="mb-8 sm:mb-10">
           <div className="flex items-center gap-3 mb-3">

--- a/frontend/src/pages/SubscriptionPage.tsx
+++ b/frontend/src/pages/SubscriptionPage.tsx
@@ -10,6 +10,7 @@ import UsageMeter from '../components/UsageMeter';
 import { useCharts, useAuth } from '../hooks';
 import type { Tier } from '../components/UsageMeter';
 
+import { Helmet } from 'react-helmet-async';
 interface PricingTierProps {
   name: string;
   tier: Tier;
@@ -190,6 +191,10 @@ export default function SubscriptionPage() {
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Subscription — AstroVerse</title>
+        <meta name="description" content="Choose your AstroVerse subscription plan." />
+      </Helmet>
       {/* Page Header */}
       <div className="mb-6 sm:mb-8">
         <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2">Subscription</h1>

--- a/frontend/src/pages/SynastryPageNew.tsx
+++ b/frontend/src/pages/SynastryPageNew.tsx
@@ -20,6 +20,7 @@ import { chartService } from '../services/chart.service';
 import { AppLayout } from '../components/AppLayout';
 import { SkeletonLoader, EmptyState } from '../components';
 
+import { Helmet } from 'react-helmet-async';
 interface SynastryPageProps {
   charts?: Chart[];
 }
@@ -203,6 +204,10 @@ const SynastryPage: React.FC<SynastryPageProps> = ({ charts: propCharts }) => {
   if (loading) {
     return (
       <AppLayout>
+      <Helmet>
+        <title>Synastry — AstroVerse</title>
+        <meta name="description" content="Compare two natal charts for relationship compatibility analysis." />
+      </Helmet>
         <div className="flex flex-col items-center justify-center min-h-[60vh]">
           <SkeletonLoader variant="card" count={2} />
         </div>

--- a/frontend/src/pages/TodayTransitsPage.tsx
+++ b/frontend/src/pages/TodayTransitsPage.tsx
@@ -24,6 +24,7 @@ import type {
 import type { TransitReading } from '../services/transit.service';
 import { useCharts, useTodayTransits } from '../hooks';
 import { getErrorMessage } from '../utils/errorHandling';
+import { Helmet } from 'react-helmet-async';
 import {
   mapReadingToTransit,
   deriveHighlights,
@@ -79,6 +80,10 @@ export default function TodayTransitsPage() {
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Today's Transits — AstroVerse</title>
+        <meta name="description" content="Current planetary transits and their influence on your day." />
+      </Helmet>
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2 gradient-text">Today's Transits</h1>
         <p className="text-slate-200">

--- a/frontend/src/pages/TransitPage.tsx
+++ b/frontend/src/pages/TransitPage.tsx
@@ -29,6 +29,7 @@ import {
   useTransitCalendar,
 } from '../hooks';
 import { getErrorMessage } from '../utils/errorHandling';
+import { Helmet } from 'react-helmet-async';
 import {
   mapReadingToTransit,
   deriveHighlights,
@@ -107,6 +108,10 @@ export default function TransitPage() {
 
   return (
     <AppLayout>
+      <Helmet>
+        <title>Transits — AstroVerse</title>
+        <meta name="description" content="Explore current and upcoming planetary transits for your chart." />
+      </Helmet>
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2 gradient-text">Current Transits</h1>
         <p className="text-slate-200">


### PR DESCRIPTION
## Summary

Three fixes in one PR:

### #334 — Document titles
Add `<Helmet>` to 23 page components missing document titles for SEO/UX.

### #328 — Test file organization
Move 3 test files from source dirs to proper `__tests__/` directories.

### #336 — Documentation accuracy
Update stale test counts in CLAUDE.md and README.md.

Closes #328
Closes #334
Closes #336