### PR TITLE
fix(security,quality): add share revoke route, fix Nominatim rate limit (#342 #345)

### DIFF
--- a/backend/src/modules/charts/routes/share.routes.ts
+++ b/backend/src/modules/charts/routes/share.routes.ts
@@ -265,4 +265,41 @@ router.get('/:token/stats', validateParams(shareTokenSchema), authenticate, asyn
   });
 }));
 
+/**
+ * @route   DELETE /api/share/:token
+ * @desc    Revoke (delete) a share link — only the share creator can revoke
+ * @access  Private (requires authentication)
+ *
+ * @openapi
+ * /api/share/{token}:
+ *   delete:
+ *     tags: [Sharing]
+ *     summary: Revoke a share link
+ *     parameters:
+ *       - in: path
+ *         name: token
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Share link revoked
+ *       404:
+ *         description: Share link not found
+ */
+router.delete('/:token', validateParams(shareTokenSchema), authenticate, asyncHandler(async (req: AuthenticatedRequest, res) => {
+  const { token } = req.params;
+
+  const revoked = await chartSharingService.revokeShareLink(token, req.user.id);
+
+  if (!revoked) {
+    throw new AppError('Share link not found or you do not have permission to revoke it', 404);
+  }
+
+  res.status(200).json({
+    success: true,
+    data: { revoked: true },
+  });
+}));
+
 export { router };

--- a/backend/src/modules/shared/routes/location.routes.ts
+++ b/backend/src/modules/shared/routes/location.routes.ts
@@ -296,6 +296,12 @@ router.get('/details/:placeId', validateParams(placeIdParamSchema), asyncHandler
 }));
 
 /**
+ * Track the last Nominatim request timestamp to enforce the 1 req/sec rate limit
+ * across ALL concurrent requests (not just per-request delay).
+ */
+let lastNominatimRequest = 0;
+
+/**
  * Fallback: Nominatim (OpenStreetMap) autocomplete
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -307,8 +313,13 @@ async function fetchNominatim(query: string): Promise<any[]> {
     url.searchParams.set('addressdetails', '1');
     url.searchParams.set('limit', '5');
 
-    // Respect Nominatim rate limit (1 req/sec)
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    // Respect Nominatim rate limit (1 req/sec) — enforce minimum 1.1s between
+    // requests globally (shared timestamp), so concurrent requests queue properly.
+    const waitMs = Math.max(0, 1100 - (Date.now() - lastNominatimRequest));
+    if (waitMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+    }
+    lastNominatimRequest = Date.now();
 
     const response = await fetchWithTimeout(url.toString(), {
       headers: {


### PR DESCRIPTION
## Summary

Two backend route fixes addressing review findings:

### #342 — P2 Security: Add DELETE route for share link revocation
The `chartSharing.service.ts` implements `revokeShareLink(shareToken, userId)` (fully tested at `chartSharing.service.test.ts:498-573`) but **no route exposed it**. This meant users could not revoke share links they created — shared charts remained accessible forever.

**Fix:** Added `DELETE /api/v1/share/:token` route in `share.routes.ts` that calls the existing service method. Requires authentication; only the share creator can revoke.

### #345 — P3 Quality: Fix Nominatim rate limit under concurrent load
The Nominatim fallback used `setTimeout(resolve, 1000)` per-request, which:
1. Does NOT prevent concurrent requests from violating the 1 req/sec limit
2. Adds 1s latency to every request, even if the last one was 10s ago

**Fix:** Replaced with a shared `lastNominatimRequest` timestamp tracker that enforces minimum 1.1s between requests globally. No unnecessary delay when last request was >1s ago.

## Changes
| File | Change |
|------|--------|
| `backend/src/modules/charts/routes/share.routes.ts` | +37 lines: DELETE route for revocation |
| `backend/src/modules/shared/routes/location.routes.ts` | +13/-2: shared timestamp rate limiter |

## Test Plan
- [x] `npx tsc --noEmit` — passes clean
- [x] `npx jest --testPathPattern=chartSharing` — 72 tests pass
- [x] `npx jest --testPathPattern="location|timezone|share"` — 66 tests pass
- [x] Existing `revokeShareLink()` service has 8 unit tests already

Closes #342
Closes #345
