### PR TITLE
fix(#358): GET /briefing/:date now queries by date, not latest — add 13 tests

### DIFF
--- a/backend/src/__tests__/controllers/briefing.controller.test.ts
+++ b/backend/src/__tests__/controllers/briefing.controller.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Briefing Controller Unit Tests
+ * Tests both exported controller functions: getBriefing, getBriefingByDate.
+ *
+ * Covers issue #358 (getBriefingByDate now queries by date, not "latest").
+ * Also provides the missing controller coverage flagged in #355.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+// ---------------------------------------------------------------------------
+// Mock Registry — mutable object so the jest.mock factories can delegate to
+// jest.fn() instances created after module setup.
+// ---------------------------------------------------------------------------
+
+const mockRegistry = {
+  getLatestBriefing: null as jest.Mock<any, any> | null,
+  getBriefingByDate: null as jest.Mock<any, any> | null,
+  generateBriefing: null as jest.Mock<any, any> | null,
+  formatBriefingContent: null as jest.Mock<any, any> | null,
+};
+
+jest.mock('../../modules/jobs/services/dailyBriefing.service', () => ({
+  __esModule: true,
+  getLatestBriefing: (...args: any[]) => (mockRegistry.getLatestBriefing as any)(...args),
+  getBriefingByDate: (...args: any[]) => (mockRegistry.getBriefingByDate as any)(...args),
+  generateBriefing: (...args: any[]) => (mockRegistry.generateBriefing as any)(...args),
+  formatBriefingContent: (...args: any[]) => (mockRegistry.formatBriefingContent as any)(...args),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks are set up)
+// ---------------------------------------------------------------------------
+
+import { Response } from 'express';
+import { getBriefing, getBriefingByDate } from '../../modules/jobs/controllers/briefing.controller';
+
+// ---------------------------------------------------------------------------
+// Wire up registry to real jest.fn() instances
+// ---------------------------------------------------------------------------
+
+mockRegistry.getLatestBriefing = jest.fn();
+mockRegistry.getBriefingByDate = jest.fn();
+mockRegistry.generateBriefing = jest.fn();
+mockRegistry.formatBriefingContent = jest.fn();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockRequest(overrides: Record<string, any> = {}) {
+  return {
+    user: { id: 'user-123', email: 'test@example.com' },
+    params: {},
+    query: {},
+    body: {},
+    ...overrides,
+  };
+}
+
+function createMockResponse() {
+  const res: Partial<Response> = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res as Response;
+}
+
+const mockBriefing = {
+  userId: 'user-123',
+  date: '2026-04-08',
+  moonPhase: { phase: 'waxing-crescent', sign: 'Taurus', illumination: 23.5 },
+  topTransits: [],
+  dailyTheme: 'A day of harmonious flow.',
+  affirmation: 'Your intentions are taking root.',
+  planetaryHighlight: { planet: 'sun', sign: 'aries', message: 'Vitality activated.' },
+};
+
+const mockContent = {
+  title: 'Your Cosmic Briefing — Wednesday, April 8',
+  summary: 'summary text',
+  pushBody: 'push body',
+  emailHtml: '<p>html</p>',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Briefing Controller', () => {
+  let mockResponse: Partial<Response>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResponse = createMockResponse();
+    mockRegistry.formatBriefingContent!.mockReturnValue(mockContent);
+  });
+
+  // =========================================================================
+  // getBriefing (GET /)
+  // =========================================================================
+  describe('getBriefing', () => {
+    it('should return cached briefing when one exists for today', async () => {
+      mockRegistry.getLatestBriefing!.mockResolvedValue(mockBriefing);
+
+      await getBriefing(createMockRequest() as any, mockResponse as Response);
+
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({ briefing: mockBriefing, content: mockContent }),
+        }),
+      );
+      // Must not generate on-the-fly when a cached briefing exists
+      expect(mockRegistry.generateBriefing).not.toHaveBeenCalled();
+    });
+
+    it('should generate on-the-fly when no cached briefing exists', async () => {
+      mockRegistry.getLatestBriefing!.mockResolvedValue(null);
+      mockRegistry.generateBriefing!.mockResolvedValue(mockBriefing);
+
+      await getBriefing(createMockRequest() as any, mockResponse as Response);
+
+      expect(mockRegistry.generateBriefing).toHaveBeenCalledWith('user-123');
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true }),
+      );
+    });
+
+    it('should return 401 when user is not authenticated', async () => {
+      await getBriefing(createMockRequest({ user: undefined }) as any, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(401);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false }),
+      );
+    });
+
+    it('should return 404 when generation fails with "No natal chart found"', async () => {
+      mockRegistry.getLatestBriefing!.mockResolvedValue(null);
+      mockRegistry.generateBriefing!.mockRejectedValue(new Error('No natal chart found for user'));
+
+      await getBriefing(createMockRequest() as any, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+    });
+
+    it('should rethrow unexpected generation errors', async () => {
+      mockRegistry.getLatestBriefing!.mockResolvedValue(null);
+      const unexpected = new Error('DB down');
+      mockRegistry.generateBriefing!.mockRejectedValue(unexpected);
+
+      await expect(
+        getBriefing(createMockRequest() as any, mockResponse as Response),
+      ).rejects.toThrow('DB down');
+    });
+  });
+
+  // =========================================================================
+  // getBriefingByDate (GET /:date) — issue #358 regression tests
+  // =========================================================================
+  describe('getBriefingByDate', () => {
+    it('should return the briefing for the requested date', async () => {
+      mockRegistry.getBriefingByDate!.mockResolvedValue(mockBriefing);
+
+      await getBriefingByDate(
+        createMockRequest({ params: { date: '2026-04-08' } }) as any,
+        mockResponse as Response,
+      );
+
+      // CRITICAL: must call getBriefingByDate(userId, date), NOT getLatestBriefing(userId)
+      expect(mockRegistry.getBriefingByDate).toHaveBeenCalledWith('user-123', '2026-04-08');
+      expect(mockRegistry.getLatestBriefing).not.toHaveBeenCalled();
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({ briefing: mockBriefing, content: mockContent }),
+        }),
+      );
+    });
+
+    it('should return 404 when no briefing exists for the date', async () => {
+      mockRegistry.getBriefingByDate!.mockResolvedValue(null);
+
+      await getBriefingByDate(
+        createMockRequest({ params: { date: '1999-01-01' } }) as any,
+        mockResponse as Response,
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.stringContaining('1999-01-01'),
+        }),
+      );
+    });
+
+    it('should return 400 for an invalid date format', async () => {
+      await getBriefingByDate(
+        createMockRequest({ params: { date: '08-04-2026' } }) as any,
+        mockResponse as Response,
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      // Must NOT hit the DB on invalid input
+      expect(mockRegistry.getBriefingByDate).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for a malformed date (not YYYY-MM-DD)', async () => {
+      await getBriefingByDate(
+        createMockRequest({ params: { date: '2026-4-8' } }) as any,
+        mockResponse as Response,
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+    });
+
+    it('should return 401 when user is not authenticated', async () => {
+      await getBriefingByDate(
+        createMockRequest({ user: undefined, params: { date: '2026-04-08' } }) as any,
+        mockResponse as Response,
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(401);
+      expect(mockRegistry.getBriefingByDate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/jobs/__tests__/dailyBriefing.service.test.ts
+++ b/backend/src/modules/jobs/__tests__/dailyBriefing.service.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { formatBriefingContent, saveBriefing, getLatestBriefing } from '../services/dailyBriefing.service';
+import { formatBriefingContent, saveBriefing, getLatestBriefing, getBriefingByDate } from '../services/dailyBriefing.service';
 import knex from '../../../config/database';
 
 // Mock dependencies
@@ -376,6 +376,87 @@ describe('DailyBriefing Service', () => {
   });
 
   // ===== Data Structure Validation =====
+
+  // ===== getBriefingByDate =====
+
+  describe('getBriefingByDate', () => {
+    it('should retrieve the briefing for the requested date', async () => {
+      // Given
+      const mockRow = {
+        user_id: mockUserId,
+        date: '2026-04-08',
+        moon_phase: JSON.stringify(mockBriefing.moonPhase),
+        top_transits: JSON.stringify(mockBriefing.topTransits),
+        daily_theme: mockBriefing.dailyTheme,
+        affirmation: mockBriefing.affirmation,
+        planetary_highlight: JSON.stringify(mockBriefing.planetaryHighlight),
+      };
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      (knex('daily_briefings').where().first as jest.MockedFunction<any>).mockResolvedValue(
+        mockRow,
+      );
+
+      // When
+      const result = await getBriefingByDate(mockUserId, '2026-04-08');
+
+      // Then
+      expect(result).not.toBeNull();
+      expect(result!.userId).toBe(mockUserId);
+      expect(result!.date).toBe('2026-04-08');
+      expect(result!.moonPhase).toEqual(mockBriefing.moonPhase);
+    });
+
+    it('should return null when no briefing exists for the date', async () => {
+      // Given
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      (knex('daily_briefings').where().first as jest.MockedFunction<any>).mockResolvedValue(
+        null,
+      );
+
+      // When
+      const result = await getBriefingByDate(mockUserId, '1999-01-01');
+
+      // Then
+      expect(result).toBeNull();
+    });
+
+    it('should query by user_id AND date (not just latest)', async () => {
+      // Given — capture the query builder returned by knex() so we can inspect
+      // how it was chained. Use a distinct resolved value so the call is real.
+      const mockRow = {
+        user_id: mockUserId,
+        date: '2026-04-08',
+        moon_phase: JSON.stringify(mockBriefing.moonPhase),
+        top_transits: JSON.stringify(mockBriefing.topTransits),
+        daily_theme: mockBriefing.dailyTheme,
+        affirmation: mockBriefing.affirmation,
+        planetary_highlight: JSON.stringify(mockBriefing.planetaryHighlight),
+      };
+      const capturedBuilder: Record<string, any> = {
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(mockRow),
+      };
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      (knex as jest.MockedFunction<typeof knex>).mockImplementationOnce(
+        () => capturedBuilder as any,
+      );
+
+      // When
+      const result = await getBriefingByDate(mockUserId, '2026-04-08');
+
+      // Then — the where clause must include BOTH user_id and date,
+      // which is what distinguishes this from getLatestBriefing (which only
+      // filters by user_id and orders by date desc).
+      expect(capturedBuilder.where).toHaveBeenCalledTimes(1);
+      expect(capturedBuilder.where).toHaveBeenCalledWith({
+        user_id: mockUserId,
+        date: '2026-04-08',
+      });
+      // Must NOT use orderBy('date','desc') like getLatestBriefing does
+      expect(capturedBuilder.orderBy).toBeUndefined();
+      expect(result!.date).toBe('2026-04-08');
+    });
+  });
 
   describe('DailyBriefing Interface', () => {
     it('should maintain valid interface structure', () => {

--- a/backend/src/modules/jobs/controllers/briefing.controller.ts
+++ b/backend/src/modules/jobs/controllers/briefing.controller.ts
@@ -9,6 +9,7 @@ import { Response } from 'express';
 import { AuthenticatedRequest } from '../../../middleware/auth';
 import {
   getLatestBriefing,
+  getBriefingByDate as fetchBriefingByDate,
   generateBriefing,
   formatBriefingContent,
 } from '../services/dailyBriefing.service';
@@ -86,9 +87,9 @@ export async function getBriefingByDate(req: AuthenticatedRequest, res: Response
     return;
   }
 
-  const briefing = await getLatestBriefing(userId);
+  const briefing = await fetchBriefingByDate(userId, date);
 
-  if (!briefing || briefing.date !== date) {
+  if (!briefing) {
     res.status(404).json({ success: false, error: `No briefing found for ${date}` });
     return;
   }

--- a/backend/src/modules/jobs/services/dailyBriefing.service.ts
+++ b/backend/src/modules/jobs/services/dailyBriefing.service.ts
@@ -260,14 +260,36 @@ export async function getLatestBriefing(userId: string): Promise<DailyBriefing |
 
   if (!row) return null;
 
+  return mapBriefingRow(row);
+}
+
+/**
+ * Get a briefing for a user on a specific date (history lookup).
+ * Returns null when no briefing exists for that exact date.
+ */
+export async function getBriefingByDate(
+  userId: string,
+  date: string,
+): Promise<DailyBriefing | null> {
+  const row = await knex('daily_briefings')
+    .where({ user_id: userId, date })
+    .first();
+
+  if (!row) return null;
+
+  return mapBriefingRow(row);
+}
+
+/** Map a raw DB row to a DailyBriefing domain object. */
+function mapBriefingRow(row: Record<string, unknown>): DailyBriefing {
   return {
-    userId: row.user_id,
-    date: row.date,
-    moonPhase: JSON.parse(row.moon_phase),
-    topTransits: JSON.parse(row.top_transits),
-    dailyTheme: row.daily_theme,
-    affirmation: row.affirmation,
-    planetaryHighlight: JSON.parse(row.planetary_highlight),
+    userId: row.user_id as string,
+    date: row.date as string,
+    moonPhase: JSON.parse(row.moon_phase as string),
+    topTransits: JSON.parse(row.top_transits as string),
+    dailyTheme: row.daily_theme as string,
+    affirmation: row.affirmation as string,
+    planetaryHighlight: JSON.parse(row.planetary_highlight as string),
   };
 }
 
@@ -472,4 +494,5 @@ export default {
   sendBriefingPush,
   saveBriefing,
   getLatestBriefing,
+  getBriefingByDate,
 };


### PR DESCRIPTION
## Changes

- fix(#358): Add `getBriefingByDate(userId, date)` to `backend/src/modules/jobs/services/dailyBriefing.service.ts`
- fix(#358): Refactor `getLatestBriefing` to share `mapBriefingRow` helper
- fix(#358): Update `briefing.controller.ts` to call date-specific service function (aliased as `fetchBriefingByDate`)
- fix(#358): Add 3 service tests + 5 controller tests for `getBriefingByDate` (found, not-found, invalid-date, unauth, query-shape)
- test: Add `briefing.controller.test.ts` (5 tests) — this controller had no test coverage (partial fix for #355)

### Test Results
- Backend: 1561 passed (1548 → 1561, +13 new tests)
- TypeScript: `npx tsc --noEmit` clean
- All new tests pass

**Required CI Checks:** backend-test, frontend-test, Coverage Gate, TDD Enforcement
