### PR TITLE
Deep Review: complete type-safe house_system mapping in updateChart (#371)

### DIFF
--- a/backend/src/__tests__/controllers/chart.controller.test.ts
+++ b/backend/src/__tests__/controllers/chart.controller.test.ts
@@ -331,14 +331,17 @@ describe('Chart Controller', () => {
 
     it('should update house system', async () => {
       mockRequest.params = { id: '456' };
-      mockRequest.validated = { house_system: 'whole_sign' };
+      mockRequest.validated = { house_system: 'whole-sign' };
 
-      (ChartModel.update as jest.Mock).mockResolvedValue({ id: '456', house_system: 'whole_sign' });
+      (ChartModel.update as jest.Mock).mockResolvedValue({ id: '456', house_system: 'whole' });
 
       await updateChart(mockRequest as Request, mockResponse as Response, mockNext);
 
       expect(ChartModel.update).toHaveBeenCalledWith('456', '123', {
-        house_system: 'whole_sign',
+        house_system: 'whole',
+        name: undefined,
+        zodiac: undefined,
+        sidereal_mode: undefined,
       });
     });
 

--- a/backend/src/modules/charts/controllers/chart.controller.ts
+++ b/backend/src/modules/charts/controllers/chart.controller.ts
@@ -227,12 +227,13 @@ export async function updateChart(req: AuthenticatedRequest, res: Response): Pro
 
   const { name, house_system, zodiac, sidereal_mode } = validatedData;
 
-  // Map validation schema values to model enum values
-  const mappedHouseSystem = house_system === 'whole-sign' ? ('whole' as any) : house_system; // eslint-disable-line @typescript-eslint/no-explicit-any
+  // Map validation schema values to model enum values using the type-safe mapper
+  // (same mapper used by createChart — maps 'whole-sign' → 'whole' without `as any`)
+  const mappedHouseSystem = house_system !== undefined ? mapHouseSystem(house_system) : undefined;
 
   const chart = await ChartModel.update(id, req.user.id, {
     name,
-    house_system: mappedHouseSystem as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    house_system: mappedHouseSystem,
     zodiac,
     sidereal_mode,
   });


### PR DESCRIPTION
## Summary

Completes the type-safety fix started in PR #370. That PR introduced `mapHouseSystem()` and applied it to `createChart()`, but `updateChart()` was left with the old `as any` casts.

## Changes

- **fix(#371):** `updateChart()` now uses `mapHouseSystem()` instead of inline ternary + `as any` — same mapper already used by `createChart()`
- Handles `undefined` `house_system` for partial updates without casting
- **fix(#371):** Corrected test — `'whole_sign'` (underscore) was never a valid Zod schema value. Test now uses valid `'whole-sign'` (hyphen) input and expects mapped `'whole'` output

### Files Changed
| File | Change |
|------|--------|
| `backend/src/modules/charts/controllers/chart.controller.ts` | Replace `as any` with `mapHouseSystem()` |
| `backend/src/__tests__/controllers/chart.controller.test.ts` | Fix invalid test input `'whole_sign'` → `'whole-sign'` |

## Verification
- ✅ `tsc --noEmit` — clean
- ✅ `eslint --max-warnings 0` — clean
- ✅ 21/21 `chart.controller` tests pass
- ✅ 14/14 `chartTypeMapping` tests pass

**Required CI:** backend-test, frontend-test, 📊 Coverage Must Not Decrease, 🧪 Tests Required for Changes

Closes #371