### PR TITLE
Deep Review: Fix controller export conventions (named exports)

### DIFF
--- a/backend/src/modules/lunar/controllers/lunarReturn.controller.ts
+++ b/backend/src/modules/lunar/controllers/lunarReturn.controller.ts
@@ -64,7 +64,7 @@ async function getUserNatalChart(userId: string): Promise<NatalChart | null> {
  * Get next lunar return date
  * GET /lunar-return/next
  */
-export const getNextLunarReturn = asyncHandler(
+const getNextLunarReturn = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.user?.id;
     if (!userId) {
@@ -93,7 +93,7 @@ export const getNextLunarReturn = asyncHandler(
  * Get current lunar return information
  * GET /lunar-return/current
  */
-export const getCurrentLunarReturn = asyncHandler(
+const getCurrentLunarReturn = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.user?.id;
     if (!userId) {
@@ -127,7 +127,7 @@ export const getCurrentLunarReturn = asyncHandler(
  * Get lunar return chart
  * POST /lunar-return/chart
  */
-export const getLunarReturnChart = asyncHandler(
+const getLunarReturnChart = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.user?.id;
     if (!userId) {
@@ -164,7 +164,7 @@ export const getLunarReturnChart = asyncHandler(
  * Get monthly forecast
  * POST /lunar-return/forecast
  */
-export const getLunarMonthForecast = asyncHandler(
+const getLunarMonthForecast = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.user?.id;
     if (!userId) {
@@ -229,7 +229,7 @@ export const getLunarMonthForecast = asyncHandler(
  * Get saved lunar returns
  * GET /lunar-return/history
  */
-export const getLunarReturnHistory = asyncHandler(
+const getLunarReturnHistory = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.user?.id;
     if (!userId) {
@@ -285,7 +285,7 @@ export const getLunarReturnHistory = asyncHandler(
  * Delete a lunar return
  * DELETE /lunar-return/:id
  */
-export const deleteLunarReturn = asyncHandler(
+const deleteLunarReturn = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.user?.id;
     const { id } = req.params;
@@ -313,7 +313,7 @@ export const deleteLunarReturn = asyncHandler(
  * Calculate custom lunar return for any date
  * POST /lunar-return/calculate
  */
-export const calculateCustomLunarReturn = asyncHandler(
+const calculateCustomLunarReturn = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.user?.id;
     if (!userId) {
@@ -356,7 +356,7 @@ export const calculateCustomLunarReturn = asyncHandler(
   },
 );
 
-export default {
+export {
   getNextLunarReturn,
   getCurrentLunarReturn,
   getLunarReturnChart,

--- a/backend/src/modules/lunar/index.ts
+++ b/backend/src/modules/lunar/index.ts
@@ -19,4 +19,3 @@ export {
   deleteLunarReturn,
   calculateCustomLunarReturn,
 } from './controllers/lunarReturn.controller';
-export { default as lunarReturnController } from './controllers/lunarReturn.controller';

--- a/backend/src/modules/synastry/controllers/synastry.controller.ts
+++ b/backend/src/modules/synastry/controllers/synastry.controller.ts
@@ -65,7 +65,7 @@ const buildChartFromRow = (row: Record<string, unknown>): Chart => {
  * Compare two natal charts
  * POST /synastry/compare
  */
-export const compareCharts = asyncHandler(
+const compareCharts = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const userId = req.user?.id;
 
@@ -146,7 +146,7 @@ export const compareCharts = asyncHandler(
  * Calculate compatibility score
  * POST /synastry/compatibility
  */
-export const getCompatibility = asyncHandler(
+const getCompatibility = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const userId = req.user?.id;
 
@@ -205,7 +205,7 @@ export const getCompatibility = asyncHandler(
  * Get all synastry comparisons for user
  * GET /synastry/reports
  */
-export const getSynastryReports = asyncHandler(
+const getSynastryReports = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const userId = req.user?.id;
 
@@ -269,7 +269,7 @@ export const getSynastryReports = asyncHandler(
  * Get specific synastry report
  * GET /synastry/reports/:id
  */
-export const getSynastryReport = asyncHandler(
+const getSynastryReport = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const userId = req.user?.id;
     const { id } = req.params;
@@ -309,7 +309,7 @@ export const getSynastryReport = asyncHandler(
  * Delete synastry report
  * DELETE /synastry/reports/:id
  */
-export const deleteSynastryReport = asyncHandler(
+const deleteSynastryReport = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const userId = req.user?.id;
     const { id } = req.params;
@@ -338,7 +338,7 @@ export const deleteSynastryReport = asyncHandler(
  * Update synastry report (notes, favorite status)
  * PATCH /synastry/reports/:id
  */
-export const updateSynastryReport = asyncHandler(
+const updateSynastryReport = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const userId = req.user?.id;
     const { id } = req.params;
@@ -377,7 +377,7 @@ export const updateSynastryReport = asyncHandler(
   },
 );
 
-export default {
+export {
   compareCharts,
   getCompatibility,
   getSynastryReports,


### PR DESCRIPTION
## Changes

### refactor(#378): Fix synastry & lunar controller export pattern

**Problem:**
- `synastry.controller.ts` and `lunarReturn.controller.ts` used `export default { ... }` pattern
- This violates project conventions which require named exports for route controllers
- Makes it impossible to use named destructuring imports in route files

**Solution:**
- Changed from `export const funcName` → `const funcName` for individual functions
- Kept `export { funcName, ... }` block at end of each file
- Removed obsolete `export { default as lunarReturnController }` from lunar/index.ts

**Files Changed:**
- `backend/src/modules/synastry/controllers/synastry.controller.ts`
- `backend/src/modules/lunar/controllers/lunarReturn.controller.ts`
- `backend/src/modules/lunar/index.ts`

**Impact:**
- No functional changes
- Controllers still work with existing route files (they use `import * as controller`)
- Now follows the same pattern as all other controllers in the codebase
- Type-safe named exports available

### Related Issues
- Fixes #378

### Required CI
- ✅ backend-test
- ✅ frontend-test
- ✅ Coverage (must not decrease)

## Why This Matters

Code conventions exist for consistency. Default exports make tree-shaking less effective and create confusing import patterns. Named exports are explicit, searchable, and work better with modern tooling.

## Testing

- Type checking passes: `npx tsc --noEmit`
- Linting passes: `npm run lint`
- Routes use `import * as controller` pattern which works with both old and new exports
- No runtime behavior changes