### PR TITLE
Deep Review: monthlyTransit controller convention fix (#404) + uiStorage location cleanup (#397)

### DIFF
--- a/backend/src/__tests__/controllers/monthlyTransit.controller.test.ts
+++ b/backend/src/__tests__/controllers/monthlyTransit.controller.test.ts
@@ -1,6 +1,9 @@
 /**
  * Monthly Transit Controller Unit Tests
- * Tests getMonthlyTransitReport function
+ * Tests getMonthlyTransitReport and getCurrentMonthlyReport functions.
+ *
+ * Controllers follow the project convention: standalone async functions
+ * (req, res) that throw AppError on failure (caught by global errorHandler).
  */
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -33,9 +36,9 @@ jest.mock('../../utils/logger', () => ({
 // Imports (after mocks are set up)
 // ---------------------------------------------------------------------------
 
-import { Response, NextFunction } from 'express';
-import { getMonthlyTransitReport } from '../../modules/reports/controllers/monthlyTransit.controller';
-import { AppError } from '../../utils/appError';
+import { Response } from 'express';
+import { getMonthlyTransitReport, getCurrentMonthlyReport } from '../../modules/reports/controllers/monthlyTransit.controller';
+import { AppError, UnauthorizedError, NotFoundError, ForbiddenError } from '../../utils/appError';
 import UserModel from '../../modules/users/models/user.model';
 
 // Mock UserModel
@@ -87,54 +90,42 @@ describe('Monthly Transit Controller', () => {
   });
 
   describe('getMonthlyTransitReport', () => {
-    it('should return 401 if user is not authenticated', async () => {
+    it('should throw UnauthorizedError (401) if user is not authenticated', async () => {
       const req = createMockRequest({ user: null });
       const res = createMockResponse();
-      const next = jest.fn() as unknown as NextFunction;
 
-      await getMonthlyTransitReport(req, res, next);
-
-      expect(next).toHaveBeenCalledWith(
-        expect.objectContaining({
-          statusCode: 401,
-          message: 'Authentication required',
-        }),
-      );
+      await expect(getMonthlyTransitReport(req, res)).rejects.toThrow(UnauthorizedError);
+      await expect(getMonthlyTransitReport(req, res)).rejects.toMatchObject({
+        statusCode: 401,
+        message: 'Authentication required',
+      });
     });
 
-    it('should return 404 if user not found', async () => {
+    it('should throw NotFoundError (404) if user not found', async () => {
       const req = createMockRequest();
       const res = createMockResponse();
-      const next = jest.fn() as unknown as NextFunction;
       (UserModel.findById as jest.Mock).mockResolvedValue(null);
 
-      await getMonthlyTransitReport(req, res, next);
-
-      expect(next).toHaveBeenCalledWith(
-        expect.objectContaining({
-          statusCode: 404,
-          message: 'User not found',
-        }),
-      );
+      await expect(getMonthlyTransitReport(req, res)).rejects.toThrow(NotFoundError);
+      await expect(getMonthlyTransitReport(req, res)).rejects.toMatchObject({
+        statusCode: 404,
+        message: 'User not found',
+      });
     });
 
-    it('should return 403 if user is not premium', async () => {
+    it('should throw ForbiddenError (403) if user is not premium', async () => {
       const req = createMockRequest();
       const res = createMockResponse();
-      const next = jest.fn() as unknown as NextFunction;
       (UserModel.findById as jest.Mock).mockResolvedValue({
         id: 'user-123',
         plan: 'free',
       });
 
-      await getMonthlyTransitReport(req, res, next);
-
-      expect(next).toHaveBeenCalledWith(
-        expect.objectContaining({
-          statusCode: 403,
-          message: expect.stringContaining('Premium subscription'),
-        }),
-      );
+      await expect(getMonthlyTransitReport(req, res)).rejects.toThrow(ForbiddenError);
+      await expect(getMonthlyTransitReport(req, res)).rejects.toMatchObject({
+        statusCode: 403,
+        message: expect.stringContaining('Premium subscription'),
+      });
     });
 
     it('should generate report for premium user', async () => {
@@ -153,7 +144,7 @@ describe('Monthly Transit Controller', () => {
       });
       mockRegistry.generateMonthlyTransitReport.mockResolvedValue(mockReport);
 
-      await getMonthlyTransitReport(req, res, jest.fn() as unknown as NextFunction);
+      await getMonthlyTransitReport(req, res);
 
       expect(UserModel.findById).toHaveBeenCalledWith('user-123');
       expect(mockRegistry.generateMonthlyTransitReport).toHaveBeenCalledWith('user-123', undefined);
@@ -179,7 +170,7 @@ describe('Monthly Transit Controller', () => {
       });
       mockRegistry.generateMonthlyTransitReport.mockResolvedValue(mockReport);
 
-      await getMonthlyTransitReport(req, res, jest.fn() as unknown as NextFunction);
+      await getMonthlyTransitReport(req, res);
 
       expect(mockRegistry.generateMonthlyTransitReport).toHaveBeenCalledWith('user-123', '2024-02');
       expect(res.json).toHaveBeenCalledWith({
@@ -188,10 +179,9 @@ describe('Monthly Transit Controller', () => {
       });
     });
 
-    it('should call next on service error', async () => {
+    it('should propagate service errors (no try/catch swallowing)', async () => {
       const req = createMockRequest();
       const res = createMockResponse();
-      const next = jest.fn() as unknown as NextFunction;
       const serviceError = new AppError('Service unavailable', 503);
       (UserModel.findById as jest.Mock).mockResolvedValue({
         id: 'user-123',
@@ -199,9 +189,41 @@ describe('Monthly Transit Controller', () => {
       });
       mockRegistry.generateMonthlyTransitReport.mockRejectedValue(serviceError);
 
-      await getMonthlyTransitReport(req, res, next);
+      // Controller should propagate the error directly (global errorHandler catches it)
+      await expect(getMonthlyTransitReport(req, res)).rejects.toBe(serviceError);
+    });
+  });
 
-      expect(next).toHaveBeenCalledWith(serviceError);
+  describe('getCurrentMonthlyReport', () => {
+    it('should throw UnauthorizedError (401) if user is not authenticated', async () => {
+      const req = createMockRequest({ user: null, method: 'GET', path: '/api/v1/reports/monthly/current' });
+      const res = createMockResponse();
+
+      await expect(getCurrentMonthlyReport(req, res)).rejects.toThrow(UnauthorizedError);
+    });
+
+    it('should generate current month report for premium user', async () => {
+      const req = createMockRequest({ method: 'GET', path: '/api/v1/reports/monthly/current' });
+      const res = createMockResponse();
+      const mockReport = {
+        userId: 'user-123',
+        month: '2024-03',
+        dailyTransits: [],
+      };
+      (UserModel.findById as jest.Mock).mockResolvedValue({
+        id: 'user-123',
+        plan: 'premium',
+      });
+      mockRegistry.generateMonthlyTransitReport.mockResolvedValue(mockReport);
+
+      await getCurrentMonthlyReport(req, res);
+
+      // Current month endpoint calls service with only userId (no month)
+      expect(mockRegistry.generateMonthlyTransitReport).toHaveBeenCalledWith('user-123');
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: mockReport,
+      });
     });
   });
 });

--- a/backend/src/modules/reports/controllers/monthlyTransit.controller.ts
+++ b/backend/src/modules/reports/controllers/monthlyTransit.controller.ts
@@ -5,7 +5,7 @@
  * CHI-123: Backend API endpoint for monthly transit reports
  */
 
-import { Response, NextFunction } from 'express';
+import { Response } from 'express';
 import { AuthenticatedRequest } from '../../../middleware/auth';
 import { generateMonthlyTransitReport } from '../services/monthlyTransit.service';
 import UserModel from '../../users/models/user.model';
@@ -46,32 +46,29 @@ async function requirePremiumUser(req: AuthenticatedRequest): Promise<void> {
 export async function getMonthlyTransitReport(
   req: AuthenticatedRequest,
   res: Response,
-  next: NextFunction,
 ): Promise<void> {
-  try {
-    await requirePremiumUser(req);
+  await requirePremiumUser(req);
 
-    const userId = req.user?.id;
-    if (!userId) {
-      throw new BadRequestError('User authentication required');
-    }
-    const { month } = req.body;
-
-    // Validate month format if provided
-    if (month && !/^\d{4}-\d{2}$/.test(month)) {
-      throw new BadRequestError('Invalid month format. Use YYYY-MM.');
-    }
-
-    // Generate monthly transit report
-    const report = await generateMonthlyTransitReport(userId, month);
-
-    res.json({
-      success: true,
-      data: report,
-    });
-  } catch (err) {
-    next(err);
+  const userId = req.user?.id;
+  if (!userId) {
+    // Should be unreachable after requirePremiumUser, but satisfies type narrowing
+    throw new UnauthorizedError('Authentication required');
   }
+  const { month } = req.body;
+
+  // Validate month format if provided (Zod schema in routes also validates,
+  // but keep this guard in case the route's validator is bypassed)
+  if (month && !/^\d{4}-\d{2}$/.test(month)) {
+    throw new BadRequestError('Invalid month format. Use YYYY-MM.');
+  }
+
+  // Generate monthly transit report
+  const report = await generateMonthlyTransitReport(userId, month);
+
+  res.json({
+    success: true,
+    data: report,
+  });
 }
 
 /**
@@ -81,24 +78,19 @@ export async function getMonthlyTransitReport(
 export async function getCurrentMonthlyReport(
   req: AuthenticatedRequest,
   res: Response,
-  next: NextFunction,
 ): Promise<void> {
-  try {
-    await requirePremiumUser(req);
+  await requirePremiumUser(req);
 
-    const userId = req.user?.id;
-    if (!userId) {
-      throw new BadRequestError('User authentication required');
-    }
-
-    // Generate current month's report
-    const report = await generateMonthlyTransitReport(userId);
-
-    res.json({
-      success: true,
-      data: report,
-    });
-  } catch (err) {
-    next(err);
+  const userId = req.user?.id;
+  if (!userId) {
+    throw new UnauthorizedError('Authentication required');
   }
+
+  // Generate current month's report
+  const report = await generateMonthlyTransitReport(userId);
+
+  res.json({
+    success: true,
+    data: report,
+  });
 }

--- a/backend/src/modules/reports/routes/monthlyTransit.routes.ts
+++ b/backend/src/modules/reports/routes/monthlyTransit.routes.ts
@@ -5,9 +5,10 @@
  * CHI-123: Backend API endpoint for monthly transit reports
  */
 
-import { Router, RequestHandler } from 'express';
+import { Router } from 'express';
 import { z } from 'zod';
-import { authenticate } from '../../../middleware/auth';
+import { authenticate, AuthenticatedRequest } from '../../../middleware/auth';
+import { asyncHandler } from '../../../middleware/errorHandler';
 import { validateBody } from '../../../utils/validators';
 import {
   getMonthlyTransitReport,
@@ -56,7 +57,7 @@ router.use(authenticate);
 router.post(
   '/',
   validateBody(monthlyReportSchema),
-  getMonthlyTransitReport as RequestHandler,
+  asyncHandler(async (req, res) => { await getMonthlyTransitReport(req as AuthenticatedRequest, res); }),
 );
 
 /**
@@ -79,7 +80,7 @@ router.post(
  */
 router.get(
   '/current',
-  getCurrentMonthlyReport as RequestHandler,
+  asyncHandler(async (req, res) => { await getCurrentMonthlyReport(req as AuthenticatedRequest, res); }),
 );
 
 export { router as monthlyTransitRoutes };

--- a/frontend/src/services/location.service.ts
+++ b/frontend/src/services/location.service.ts
@@ -8,7 +8,7 @@ import { logger } from '@/utils/logger';
 
 import api from './api';
 import type { Location, GeocodingResult, ApiResponse } from './api.types';
-import { getRecentLocationSearches as getRecentSearchesFromStorage, addRecentLocationSearch as addRecentSearchToStorage } from '@/utils/uiStorage';
+import { getRecentLocationSearches as getRecentSearchesFromStorage, addRecentLocationSearch as addRecentSearchToStorage, clearRecentLocationSearches as clearRecentSearchesFromStorage } from '@/utils/uiStorage';
 
 /**
  * Location Service Class
@@ -210,7 +210,7 @@ class LocationService {
    */
   clearRecentSearches(): void {
     try {
-      localStorage.removeItem('recentLocationSearches');
+      clearRecentSearchesFromStorage();
     } catch (error) {
       logger.error('Failed to clear recent searches:', error);
     }

--- a/frontend/src/utils/uiStorage.ts
+++ b/frontend/src/utils/uiStorage.ts
@@ -72,6 +72,17 @@ export function addRecentLocationSearch(location: { name: string; country: strin
 }
 
 /**
+ * Clear all recent location searches
+ */
+export function clearRecentLocationSearches(): void {
+  try {
+    localStorage.removeItem(KEYS.RECENT_LOCATION_SEARCHES);
+  } catch {
+    // Silently swallow storage errors (e.g. private mode)
+  }
+}
+
+/**
  * Get Learn page completed sections
  */
 export function getLearnPageCompleted(): string[] {


### PR DESCRIPTION
## Changes

### refactor(#404): monthlyTransit controller convention fix

""""diff
# Before (ONLY controller using next param + try/catch)
export async function getMonthlyTransitReport(req, res, next: NextFunction) {
  try { ... } catch (err) { next(err); }
}
"""
""""diff
# After (matches every other controller: throw AppError, no next, no try/catch)
export async function getMonthlyTransitReport(req, res): Promise<void> {
  await requirePremiumUser(req);
  throw new UnauthorizedError("...");
  res.json({ success: true, data: report });
}
"""

`monthlyTransit.controller.ts` was the **only** controller in the entire backend that used the `next` parameter and wrapped logic in `try/catch`. Per `CLAUDE.md`, controllers take `(req, res)` only and throw `AppError` (caught by global `errorHandler`). This also removed the `as RequestHandler` casts that were needed to satisfy Express typings, replaced with `asyncHandler` wrappers matching the `ai.routes.ts` pattern.

- Removed `next: NextFunction` param from both `getMonthlyTransitReport` and `getCurrentMonthlyReport`
- Removed `try/catch` wrappers (errors propagate to global `errorHandler`)
- Updated `monthlyTransit.routes.ts`: dropped `as RequestHandler` casts, use `asyncHandler` wrapper
- Updated `monthlyTransit.controller.test.ts`: assertions now check thrown errors (rejects.toThrow) instead of `next` being called; added test for `getCurrentMonthlyReport`

### refactor(#397): uiStorage location cleanup

`location.service.ts:clearRecentSearches()` used raw `localStorage.removeItem()` while the rest of the file already routed through the `uiStorage` utility. Added `clearRecentLocationSearches()` to `uiStorage.ts` and wired it in.

**Required CI:** backend-test, frontend-test, 📊 Coverage Must Not Decrease, 🧪 Tests Required for Changes

Closes #404
