### PR TITLE
Auto-Review Fix: Replace direct localStorage access with uiStorage utility

### DIFF
--- a/frontend/src/components/user-profile/PreferencesTab.tsx
+++ b/frontend/src/components/user-profile/PreferencesTab.tsx
@@ -1,4 +1,5 @@
 import type { UserProfile } from './types';
+import { setTheme } from '../../utils/uiStorage';
 
 export interface PreferencesTabProps {
   user?: UserProfile;
@@ -150,7 +151,7 @@ export function PreferencesTab({ user }: PreferencesTabProps) {
                       root.classList.add('light');
                     }
                   }
-                  localStorage.setItem('theme', theme.value);
+                  setTheme(theme.value);
                 }}
                 className={`
                   p-4 rounded-lg border-2 text-center transition-all


### PR DESCRIPTION
## Changes

- fix(#406): Replace direct `localStorage.setItem('theme', ...)` with `setTheme(...)` from uiStorage utility in PreferencesTab.tsx

## Context
Direct localStorage access violates the project's convention of using the centralized `uiStorage` utility for non-auth UI preferences. This change ensures consistency and makes storage operations easier to track and debug.

**Required CI Checks:** backend-test, frontend-test, Coverage Gate, TDD Enforcement