### PR TITLE
Auto-Review Fix: SynastryPageNew async effect cleanup (#416)

### DIFF
--- a/frontend/src/pages/SynastryPageNew.tsx
+++ b/frontend/src/pages/SynastryPageNew.tsx
@@ -43,23 +43,29 @@ const SynastryPage: React.FC<SynastryPageProps> = ({ charts: propCharts }) => {
   } | null>(null);
 
   useEffect(() => {
+    // Mounted guard prevents state updates after unmount (async effect cleanup).
+    // Without this, `setLoading(false)` in the finally block fires after the
+    // component unmounts, causing an unhandled rejection in tests (and a real
+    // race in the live app if the user navigates away while charts are loading).
+    let mounted = true;
     if (!propCharts) {
-      void loadCharts();
+      void (async () => {
+        try {
+          setLoading(true);
+          const { charts: loadedCharts } = await chartService.getCharts();
+          if (mounted) setCharts(loadedCharts);
+        } catch (err) {
+          logger.error('Error loading charts:', err);
+          if (mounted) setError('Failed to load charts');
+        } finally {
+          if (mounted) setLoading(false);
+        }
+      })();
     }
+    return () => {
+      mounted = false;
+    };
   }, [propCharts]);
-
-  const loadCharts = async () => {
-    try {
-      setLoading(true);
-      const { charts: loadedCharts } = await chartService.getCharts();
-      setCharts(loadedCharts);
-    } catch (err) {
-      logger.error('Error loading charts:', err);
-      setError('Failed to load charts');
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const handleSwap = () => {
     const temp = chart1Id;


### PR DESCRIPTION
## Changes

- **fix(#416): add mounted guard to SynastryPageNew async effect**

`SynastryPageNew.test.tsx` emitted an unhandled rejection (`window is not defined`) during test teardown. Root cause: the async `loadCharts()` effect in `SynastryPageNew.tsx` had no cleanup, so `setLoading(false)` in the `finally` block fired after the component unmounted (jsdom `window` already destroyed).

### Fix
Added the standard React mounted-guard pattern so state setters (`setLoading`, `setCharts`, `setError`) are skipped after unmount. Also removed the now-dead standalone `loadCharts` function.

This is a **production-quality fix** — the same race exists in the live app if a user navigates away from the Synastry page while charts are loading — not a test-only patch.

### Verification
- ✅ `npx vitest run` → 3887 tests pass, **0 errors** (previously reported `Errors: 1 error` + an Unhandled Rejection warning)
- ✅ `npx tsc --noEmit` → clean
- ✅ `npx eslint src/pages/SynastryPageNew.tsx` → clean
- ✅ `SynastryPageNew.test.tsx` → 20/20 pass

**Required CI Checks:** backend-test, frontend-test, 📊 Coverage Must Not Decrease, 🧪 Tests Required for Changes