### PR TITLE
Deep Review: Skip links navigation + controller tests for ai, blog, and card

### DIFF
--- a/backend/src/__tests__/controllers/ai.controller.test.ts
+++ b/backend/src/__tests__/controllers/ai.controller.test.ts
@@ -1,0 +1,429 @@
+/**
+ * AI Controller Unit Tests
+ *
+ * Tests the actual exported functions from ai.controller.ts:
+ *   generateNatal, generateTransit, generateCompatibility,
+ *   generateLunarReturn, generateSolarReturn, checkStatus,
+ *   getUsageStats, clearCache
+ *
+ * ai.controller exports plain async functions with signature
+ * (req: AuthenticatedRequest, res: Response) => Promise<void>.
+ * They throw AppError for validation errors and call res.json() on success.
+ * In production the route layer wraps them in asyncHandler(); here we call
+ * them directly and assert the thrown rejection / res.json response.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import type { Response } from 'express';
+import { AppError } from '../../utils/appError';
+import {
+  generateNatal,
+  generateTransit,
+  generateCompatibility,
+  generateLunarReturn,
+  generateSolarReturn,
+  checkStatus,
+  getUsageStats,
+  clearCache,
+} from '../../modules/ai/controllers/ai.controller';
+
+// ---------------------------------------------------------------------------
+// Mocks — both services export class instances via `export default new Cls()`.
+// jest.mock() factories are hoisted above const declarations, so we use a
+// mutable registry and delegate to it lazily (per the repo's mock-hoisting
+// gotcha documented in CLAUDE.md).
+// ---------------------------------------------------------------------------
+
+const mockInterpretation: Record<string, jest.Mock> = {};
+
+jest.mock('../../modules/ai/services/aiInterpretation.service', () => ({
+  __esModule: true,
+  default: new Proxy(
+    {},
+    {
+      get: (_t, prop) => mockInterpretation[prop as string],
+    },
+  ),
+}));
+
+const mockOpenai: Record<string, jest.Mock> = {};
+
+jest.mock('../../modules/ai/services/openai.service', () => ({
+  __esModule: true,
+  default: new Proxy(
+    {},
+    {
+      get: (_t, prop) => mockOpenai[prop as string],
+    },
+  ),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockUser = { id: 'user-123', email: 'test@example.com' };
+
+const chartData = {
+  planets: [
+    { name: 'Sun', sign: 'Leo', degree: 15.5, house: 5 },
+    { name: 'Moon', sign: 'Cancer', degree: 10.2, house: 4 },
+  ],
+  houses: [{ number: 1, sign: 'Aries', cusp: 0 }],
+  aspects: [{ planet1: 'Sun', planet2: 'Moon', type: 'trine', degree: 120 }],
+};
+
+const transitData = {
+  natalChart: chartData,
+  currentTransits: [
+    { planet: 'Jupiter', sign: 'Taurus', degree: 5.5, aspect: 'conjunction', natalPlanet: 'Sun' },
+  ],
+  startDate: '2026-06-29',
+  endDate: '2026-07-29',
+};
+
+// controller destructures chartA/chartB from validated payload
+const synastryData = {
+  chartA: chartData,
+  chartB: { ...chartData, planets: [{ name: 'Sun', sign: 'Scorpio', degree: 1, house: 1 }] },
+};
+
+const interpretationResult = {
+  interpretation: 'You are a confident and creative person...',
+  keyThemes: ['Leadership', 'Creativity'],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnThis();
+  res.json = jest.fn().mockReturnThis();
+  return res as Response;
+}
+
+function buildReq(overrides: any = {}): any {
+  return {
+    user: mockUser,
+    validated: undefined,
+    method: 'POST',
+    path: '/api/v1/ai/natal',
+    ...overrides,
+  };
+}
+
+describe('AI Controller', () => {
+  let res: Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    res = buildRes();
+
+    // Populate the mock registries with fresh jest.fn() instances.
+    // These are created here (after jest.mock hoisting) and assigned onto the
+    // shared registry objects that the module-level Proxies delegate to.
+    for (const m of [
+      'generateNatal',
+      'generateTransit',
+      'generateCompatibility',
+      'generateLunarReturn',
+      'generateSolarReturn',
+      'clearCache',
+    ]) {
+      mockInterpretation[m] = jest.fn();
+    }
+    for (const m of ['isConfigured', 'getConfigStatus', 'getUsageStats']) {
+      mockOpenai[m] = jest.fn();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  describe('generateNatal', () => {
+    it('should generate a natal interpretation successfully', async () => {
+      mockInterpretation.generateNatal.mockResolvedValue(interpretationResult);
+      const req = buildReq({ validated: chartData });
+
+      await generateNatal(req, res);
+
+      expect(mockInterpretation.generateNatal).toHaveBeenCalledWith(chartData);
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: interpretationResult });
+    });
+
+    it('should throw AppError 400 when chart data is missing', async () => {
+      const req = buildReq({ validated: null });
+      await expect(generateNatal(req, res)).rejects.toThrow(AppError);
+    });
+
+    it('should throw AppError 400 when planets array is empty', async () => {
+      const req = buildReq({ validated: { planets: [] } });
+      await expect(generateNatal(req, res)).rejects.toThrow(/planet/i);
+    });
+
+    it('should throw AppError 400 when planets array is undefined', async () => {
+      const req = buildReq({ validated: {} });
+      await expect(generateNatal(req, res)).rejects.toThrow(AppError);
+    });
+
+    it('should propagate service errors', async () => {
+      mockInterpretation.generateNatal.mockRejectedValue(new Error('AI service unavailable'));
+      const req = buildReq({ validated: chartData });
+      await expect(generateNatal(req, res)).rejects.toThrow('AI service unavailable');
+    });
+
+    it('should log the generation request with userId', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const logger = require('../../utils/logger').default;
+      mockInterpretation.generateNatal.mockResolvedValue(interpretationResult);
+      const req = buildReq({ validated: chartData });
+
+      await generateNatal(req, res);
+
+      expect(logger.info).toHaveBeenCalledWith('Generating AI natal interpretation', {
+        userId: mockUser.id,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('generateTransit', () => {
+    it('should generate a transit forecast successfully', async () => {
+      const forecast = { interpretation: 'Jupiter conjunct Sun brings opportunities' };
+      mockInterpretation.generateTransit.mockResolvedValue(forecast);
+      const req = buildReq({ validated: transitData });
+
+      await generateTransit(req, res);
+
+      expect(mockInterpretation.generateTransit).toHaveBeenCalledWith(transitData);
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: forecast });
+    });
+
+    it('should throw AppError 400 when transit data is missing', async () => {
+      const req = buildReq({ validated: null });
+      await expect(generateTransit(req, res)).rejects.toThrow(AppError);
+    });
+
+    it('should throw AppError 400 when currentTransits is empty', async () => {
+      const req = buildReq({ validated: { currentTransits: [] } });
+      await expect(generateTransit(req, res)).rejects.toThrow(AppError);
+    });
+
+    it('should throw AppError 400 when currentTransits is undefined', async () => {
+      const req = buildReq({ validated: {} });
+      await expect(generateTransit(req, res)).rejects.toThrow(AppError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('generateCompatibility', () => {
+    it('should generate a compatibility report successfully', async () => {
+      const report = { interpretation: 'Strong compatibility', compatibilityScore: 85 };
+      mockInterpretation.generateCompatibility.mockResolvedValue(report);
+      const req = buildReq({ validated: synastryData });
+
+      await generateCompatibility(req, res);
+
+      expect(mockInterpretation.generateCompatibility).toHaveBeenCalledWith({
+        chartA: synastryData.chartA,
+        chartB: synastryData.chartB,
+      });
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: report });
+    });
+
+    it('should throw AppError 400 when both charts missing', async () => {
+      // validated is an object but neither chart is present — controller checks
+      // `if (!chartA || !chartB)` and throws AppError 400.
+      const req = buildReq({ validated: {} });
+      await expect(generateCompatibility(req, res)).rejects.toThrow(AppError);
+    });
+
+    it('should throw AppError 400 when chartA is missing', async () => {
+      const req = buildReq({ validated: { chartB: chartData } });
+      await expect(generateCompatibility(req, res)).rejects.toThrow(AppError);
+    });
+
+    it('should throw AppError 400 when chartB is missing', async () => {
+      const req = buildReq({ validated: { chartA: chartData } });
+      await expect(generateCompatibility(req, res)).rejects.toThrow(AppError);
+    });
+
+    it('should throw AppError 400 when chartA has no planets', async () => {
+      const req = buildReq({
+        validated: {
+          chartA: { planets: [] },
+          chartB: chartData,
+        },
+      });
+      await expect(generateCompatibility(req, res)).rejects.toThrow(AppError);
+    });
+
+    it('should throw AppError 400 when chartB has no planets', async () => {
+      const req = buildReq({
+        validated: {
+          chartA: chartData,
+          chartB: { planets: [] },
+        },
+      });
+      await expect(generateCompatibility(req, res)).rejects.toThrow(AppError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('generateLunarReturn', () => {
+    it('should generate a lunar return interpretation successfully', async () => {
+      mockInterpretation.generateLunarReturn.mockResolvedValue(interpretationResult);
+      const req = buildReq({ validated: chartData });
+
+      await generateLunarReturn(req, res);
+
+      expect(mockInterpretation.generateLunarReturn).toHaveBeenCalledWith(chartData);
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: interpretationResult });
+    });
+
+    it('should throw AppError 400 when chart data is missing', async () => {
+      const req = buildReq({ validated: null });
+      await expect(generateLunarReturn(req, res)).rejects.toThrow(AppError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('generateSolarReturn', () => {
+    it('should generate a solar return interpretation successfully', async () => {
+      mockInterpretation.generateSolarReturn.mockResolvedValue(interpretationResult);
+      const req = buildReq({ validated: chartData });
+
+      await generateSolarReturn(req, res);
+
+      expect(mockInterpretation.generateSolarReturn).toHaveBeenCalledWith(chartData);
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: interpretationResult });
+    });
+
+    it('should throw AppError 400 when chart data is missing', async () => {
+      const req = buildReq({ validated: null });
+      await expect(generateSolarReturn(req, res)).rejects.toThrow(AppError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('checkStatus', () => {
+    it('should report available when configured', async () => {
+      mockOpenai.isConfigured.mockReturnValue(true);
+      const configStatus = { model: 'gpt-4' };
+      mockOpenai.getConfigStatus.mockReturnValue(configStatus);
+
+      const req: any = {};
+      await checkStatus(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: {
+          available: true,
+          service: 'openai',
+          model: 'gpt-4',
+        },
+      });
+    });
+
+    it('should report unavailable when not configured', async () => {
+      mockOpenai.isConfigured.mockReturnValue(false);
+      mockOpenai.getConfigStatus.mockReturnValue({ model: null });
+
+      const req: any = {};
+      await checkStatus(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({ available: false, service: null }),
+        }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getUsageStats', () => {
+    it('should return usage statistics', async () => {
+      const stats = { available: true, usage: { totalRequests: 10, totalTokens: 500, totalCost: 0.02 } };
+      mockOpenai.getUsageStats.mockResolvedValue(stats);
+
+      const req: any = {};
+      await getUsageStats(req, res);
+
+      expect(mockOpenai.getUsageStats).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: stats });
+    });
+
+    it('should propagate service errors', async () => {
+      mockOpenai.getUsageStats.mockRejectedValue(new Error('DB down'));
+      const req: any = {};
+      await expect(getUsageStats(req, res)).rejects.toThrow('DB down');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('clearCache', () => {
+    it('should clear the cache and log the action', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const logger = require('../../utils/logger').default;
+      mockInterpretation.clearCache.mockResolvedValue(undefined);
+      const req = buildReq();
+
+      await clearCache(req, res);
+
+      expect(mockInterpretation.clearCache).toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith('AI interpretation cache cleared', {
+        userId: mockUser.id,
+      });
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        message: 'Cache cleared successfully',
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('AuthenticatedRequest type safety', () => {
+    it('should access user.id from AuthenticatedRequest on success path', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const logger = require('../../utils/logger').default;
+      mockInterpretation.generateNatal.mockResolvedValue(interpretationResult);
+      const req = buildReq({ validated: chartData });
+
+      await generateNatal(req, res);
+
+      // logger.info receives the user.id extracted from req.user — proving
+      // the controller reads the authenticated user from AuthenticatedRequest.
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ userId: mockUser.id }),
+      );
+    });
+
+    it('should access user.id when clearing cache', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const logger = require('../../utils/logger').default;
+      mockInterpretation.clearCache.mockResolvedValue(undefined);
+      const req = buildReq();
+
+      await clearCache(req, res);
+
+      expect(logger.info).toHaveBeenCalledWith('AI interpretation cache cleared', {
+        userId: mockUser.id,
+      });
+    });
+  });
+});

--- a/backend/src/__tests__/controllers/blog.controller.test.ts
+++ b/backend/src/__tests__/controllers/blog.controller.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Blog Controller Unit Tests
+ *
+ * blog.controller.ts exports handlers wrapped in asyncHandler(), i.e. they are
+ * middleware-style functions with signature (req, res, next). On success they
+ * write to res; on error they throw, and asyncHandler forwards the thrown
+ * error to next(). So tests call the handler with a mock next and assert:
+ *   - success: res.status/res.json called, next NOT called
+ *   - error:   next called with an AppError
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import type { Response, NextFunction } from 'express';
+import { AppError } from '../../utils/appError';
+import {
+  createPost,
+  getPosts,
+  getPost,
+  updatePost,
+  deletePost,
+} from '../../modules/blog/controllers/blog.controller';
+
+// blog.service exports a class instance: `export const blogService = new BlogService()`
+const mockBlogService: Record<string, jest.Mock> = {};
+
+jest.mock('../../modules/blog/services/blog.service', () => ({
+  __esModule: true,
+  blogService: new Proxy(
+    {},
+    {
+      get: (_t, prop) => mockBlogService[prop as string],
+    },
+  ),
+}));
+
+// blog.controller imports multer — avoid touching the filesystem in unit tests.
+jest.mock('multer', () => {
+  const multer = () => ({
+    single: () => (_req: any, _res: any, next: NextFunction) => next(),
+  });
+  (multer as any).memoryStorage = () => ({});
+  return { __esModule: true, default: multer };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockUser = { id: 'user-123', email: 'admin@example.com', role: 'admin' };
+
+const mockPost = {
+  id: 'post-123',
+  title: 'Understanding Mercury Retrograde',
+  body: 'Mercury retrograde is a time for reflection...',
+  author_id: mockUser.id,
+  is_published: true,
+  created_at: '2026-06-29T00:00:00Z',
+  updated_at: '2026-06-29T00:00:00Z',
+};
+
+const mockPosts = [mockPost, { ...mockPost, id: 'post-456', title: 'New Moon in Cancer' }];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnThis();
+  res.json = jest.fn().mockReturnThis();
+  return res as Response;
+}
+
+function buildReq(overrides: any = {}): any {
+  return {
+    user: mockUser,
+    body: {},
+    params: {},
+    query: {},
+    file: undefined,
+    method: 'POST',
+    path: '/api/v1/blog',
+    ...overrides,
+  };
+}
+
+describe('Blog Controller', () => {
+  let res: Response;
+  let next: jest.MockedFunction<NextFunction>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    res = buildRes();
+    next = jest.fn();
+
+    // Register fresh mocks for every service method the controller uses.
+    for (const m of [
+      'createPost',
+      'getPublishedPosts',
+      'getPostById',
+      'updatePost',
+      'deletePost',
+      'saveImage',
+      'getAllPosts',
+    ]) {
+      mockBlogService[m] = jest.fn();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  describe('createPost', () => {
+    it('should create a blog post successfully', async () => {
+      const req = buildReq({
+        body: { title: 'Understanding Mercury Retrograde', body: 'Mercury retrograde...', is_published: true },
+      });
+      mockBlogService.createPost.mockResolvedValue(mockPost);
+
+      await createPost(req, res, next);
+
+      expect(mockBlogService.createPost).toHaveBeenCalledWith({
+        author_id: mockUser.id,
+        title: 'Understanding Mercury Retrograde',
+        body: 'Mercury retrograde...',
+        is_published: true,
+      });
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: mockPost });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should default is_published to true when not provided', async () => {
+      const req = buildReq({ body: { title: 'Test Post', body: 'Test body' } });
+      mockBlogService.createPost.mockResolvedValue(mockPost);
+
+      await createPost(req, res, next);
+
+      expect(mockBlogService.createPost).toHaveBeenCalledWith(
+        expect.objectContaining({ is_published: true }),
+      );
+    });
+
+    it('should default is_published to true when explicitly false (preserves false)', async () => {
+      // is_published !== false -> true; false stays false.
+      const req = buildReq({ body: { title: 'Draft', body: 'Draft body', is_published: false } });
+      const draftPost = { ...mockPost, is_published: false };
+      mockBlogService.createPost.mockResolvedValue(draftPost);
+
+      await createPost(req, res, next);
+
+      expect(mockBlogService.createPost).toHaveBeenCalledWith(
+        expect.objectContaining({ is_published: false }),
+      );
+    });
+
+    it('should forward service errors to next()', async () => {
+      const req = buildReq({ body: { title: 'Test', body: 'Body' } });
+      mockBlogService.createPost.mockRejectedValue(new Error('Database error'));
+
+      await createPost(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = next.mock.calls[0][0];
+      // asyncHandler wraps non-AppError errors with request context message
+      expect(err).toBeInstanceOf(Error);
+      expect(String(err.message)).toMatch(/Database error/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getPosts', () => {
+    it('should get published posts with default pagination', async () => {
+      const req = buildReq({ query: {} });
+      mockBlogService.getPublishedPosts.mockResolvedValue({ posts: mockPosts, total: 2 });
+
+      await getPosts(req, res, next);
+
+      expect(mockBlogService.getPublishedPosts).toHaveBeenCalledWith(20, 0);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: { posts: mockPosts, total: 2, limit: 20, offset: 0 },
+      });
+    });
+
+    it('should handle custom pagination parameters', async () => {
+      const req = buildReq({ query: { limit: '10', offset: '20' } });
+      mockBlogService.getPublishedPosts.mockResolvedValue({ posts: mockPosts.slice(0, 1), total: 2 });
+
+      await getPosts(req, res, next);
+
+      expect(mockBlogService.getPublishedPosts).toHaveBeenCalledWith(10, 20);
+    });
+
+    it('should enforce maximum limit of 50', async () => {
+      const req = buildReq({ query: { limit: '100', offset: '0' } });
+      mockBlogService.getPublishedPosts.mockResolvedValue({ posts: [], total: 0 });
+
+      await getPosts(req, res, next);
+
+      expect(mockBlogService.getPublishedPosts).toHaveBeenCalledWith(50, 0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getPost', () => {
+    it('should get a post by id', async () => {
+      const req = buildReq({ params: { id: 'post-123' } });
+      mockBlogService.getPostById.mockResolvedValue(mockPost);
+
+      await getPost(req, res, next);
+
+      expect(mockBlogService.getPostById).toHaveBeenCalledWith('post-123');
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: mockPost });
+    });
+
+    it('should call next() with AppError 404 for non-existent posts', async () => {
+      const req = buildReq({ params: { id: 'nonexistent' } });
+      mockBlogService.getPostById.mockResolvedValue(null);
+
+      await getPost(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(404);
+      expect(err.message).toMatch(/not found/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('updatePost', () => {
+    it('should update a blog post successfully', async () => {
+      const req = buildReq({
+        params: { id: 'post-123' },
+        body: { title: 'Updated', body: 'Updated content', is_published: true },
+      });
+      const updatedPost = { ...mockPost, title: 'Updated' };
+      mockBlogService.updatePost.mockResolvedValue(updatedPost);
+
+      await updatePost(req, res, next);
+
+      expect(mockBlogService.updatePost).toHaveBeenCalledWith('post-123', {
+        title: 'Updated',
+        body: 'Updated content',
+        is_published: true,
+        image_url: undefined,
+      });
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: updatedPost });
+    });
+
+    it('should update post with image_url', async () => {
+      const req = buildReq({
+        params: { id: 'post-123' },
+        body: { image_url: 'https://cdn.example.com/image.jpg' },
+      });
+      const updatedPost = { ...mockPost, image_url: 'https://cdn.example.com/image.jpg' };
+      mockBlogService.updatePost.mockResolvedValue(updatedPost);
+
+      await updatePost(req, res, next);
+
+      expect(mockBlogService.updatePost).toHaveBeenCalledWith('post-123', {
+        title: undefined,
+        body: undefined,
+        is_published: undefined,
+        image_url: 'https://cdn.example.com/image.jpg',
+      });
+    });
+
+    it('should call next() with AppError 404 when updating non-existent posts', async () => {
+      const req = buildReq({ params: { id: 'nonexistent' }, body: { title: 'Test' } });
+      mockBlogService.updatePost.mockResolvedValue(null);
+
+      await updatePost(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(404);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('deletePost', () => {
+    it('should delete a blog post successfully', async () => {
+      const req = buildReq({ params: { id: 'post-123' } });
+      mockBlogService.deletePost.mockResolvedValue(true);
+
+      await deletePost(req, res, next);
+
+      expect(mockBlogService.deletePost).toHaveBeenCalledWith('post-123');
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: { deleted: true } });
+    });
+
+    it('should call next() with AppError 404 when deleting non-existent posts', async () => {
+      const req = buildReq({ params: { id: 'nonexistent' } });
+      mockBlogService.deletePost.mockResolvedValue(false);
+
+      await deletePost(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(404);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('AuthenticatedRequest type safety', () => {
+    it('should pass user.id as author_id from AuthenticatedRequest', async () => {
+      const req = buildReq({ body: { title: 'Test', body: 'Body' } });
+      mockBlogService.createPost.mockResolvedValue(mockPost);
+
+      await createPost(req, res, next);
+
+      expect(mockBlogService.createPost).toHaveBeenCalledWith(
+        expect.objectContaining({ author_id: mockUser.id }),
+      );
+    });
+  });
+});

--- a/backend/src/__tests__/controllers/card.controller.test.ts
+++ b/backend/src/__tests__/controllers/card.controller.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Card Controller Unit Tests
+ *
+ * card.controller.ts exports handlers wrapped in asyncHandler(), i.e. they are
+ * middleware-style functions with signature (req, res, next). On success they
+ * write to res; on error they throw, and asyncHandler forwards the thrown
+ * error to next(). Tests call the handler with a mock next and assert:
+ *   - success: res.status/res.json called, next NOT called
+ *   - error:   next called with an AppError
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import type { Response, NextFunction } from 'express';
+import { AppError } from '../../utils/appError';
+import {
+  generateCard,
+  getCard,
+  getPublicCard,
+  getCardHistory,
+  deleteCard,
+  getOgData,
+} from '../../modules/cards/controllers/card.controller';
+const mockCardService: Record<string, jest.Mock> = {};
+
+jest.mock('../../modules/cards/services/card.service', () => ({
+  __esModule: true,
+  cardService: new Proxy(
+    {},
+    {
+      get: (_t, prop) => mockCardService[prop as string],
+    },
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockUser = { id: 'user-123', email: 'test@example.com' };
+
+const mockCard = {
+  id: 'card-123',
+  user_id: mockUser.id,
+  chart_id: 'chart-1',
+  share_token: 'tok-abc123def456',
+  template: 'instagram_story',
+  planet_placements: ['Sun in Leo', 'Moon in Cancer'],
+  show_insight: true,
+  insight_text: 'A confident and creative soul.',
+  image_url: 'https://cdn.example.com/card.png',
+  is_public: true,
+  og_title: 'My Chart',
+  og_description: 'Sun in Leo',
+  referral_code: undefined,
+  view_count: 0,
+  created_at: new Date('2026-06-29'),
+  updated_at: new Date('2026-06-29'),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnThis();
+  res.json = jest.fn().mockReturnThis();
+  return res as Response;
+}
+
+function buildReq(overrides: any = {}): any {
+  return {
+    user: mockUser,
+    body: {},
+    params: {},
+    query: {},
+    method: 'POST',
+    path: '/api/v1/cards/generate',
+    ...overrides,
+  };
+}
+
+describe('Card Controller', () => {
+  let res: Response;
+  let next: jest.MockedFunction<NextFunction>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    res = buildRes();
+    next = jest.fn();
+
+    for (const m of [
+      'generateCard',
+      'getCardById',
+      'getPublicCard',
+      'getUserCards',
+      'deleteCard',
+      'getOgData',
+    ]) {
+      mockCardService[m] = jest.fn();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  describe('generateCard', () => {
+    it('should generate a shareable card successfully', async () => {
+      const req = buildReq({
+        body: {
+          chart_id: 'chart-1',
+          template: 'instagram_story',
+          planet_placements: ['Sun in Leo'],
+          show_insight: true,
+        },
+      });
+      mockCardService.generateCard.mockResolvedValue(mockCard);
+
+      await generateCard(req, res, next);
+
+      expect(mockCardService.generateCard).toHaveBeenCalledWith(
+        mockUser.id,
+        'chart-1',
+        expect.objectContaining({ template: 'instagram_story' }),
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: expect.objectContaining({ id: 'card-123', share_token: 'tok-abc123def456' }),
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should call next() with AppError 400 when chart_id is missing', async () => {
+      const req = buildReq({ body: {} });
+
+      await generateCard(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(400);
+      expect(mockCardService.generateCard).not.toHaveBeenCalled();
+    });
+
+    it('should forward service errors to next()', async () => {
+      const req = buildReq({ body: { chart_id: 'chart-1' } });
+      mockCardService.generateCard.mockRejectedValue(new Error('image render failed'));
+
+      await generateCard(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(Error);
+      expect(String(err.message)).toMatch(/image render failed/);
+    });
+
+    it('should use user.id from AuthenticatedRequest', async () => {
+      const req = buildReq({ body: { chart_id: 'chart-1' } });
+      mockCardService.generateCard.mockResolvedValue(mockCard);
+
+      await generateCard(req, res, next);
+
+      expect(mockCardService.generateCard).toHaveBeenCalledWith(
+        mockUser.id,
+        expect.any(String),
+        expect.anything(),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getCard', () => {
+    it('should get card metadata for owner', async () => {
+      const req = buildReq({ params: { id: 'card-123' } });
+      mockCardService.getCardById.mockResolvedValue(mockCard);
+
+      await getCard(req, res, next);
+
+      expect(mockCardService.getCardById).toHaveBeenCalledWith('card-123', mockUser.id);
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: mockCard });
+    });
+
+    it('should call next() with AppError 404 when card not found', async () => {
+      const req = buildReq({ params: { id: 'nope' } });
+      mockCardService.getCardById.mockResolvedValue(null);
+
+      await getCard(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(404);
+    });
+
+    it('should forward service errors to next()', async () => {
+      const req = buildReq({ params: { id: 'card-123' } });
+      mockCardService.getCardById.mockRejectedValue(new Error('DB error'));
+
+      await getCard(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+    });
+
+    it('should use user.id for authorization', async () => {
+      const req = buildReq({ params: { id: 'card-123' } });
+      mockCardService.getCardById.mockResolvedValue(mockCard);
+
+      await getCard(req, res, next);
+
+      expect(mockCardService.getCardById).toHaveBeenCalledWith('card-123', mockUser.id);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getPublicCard', () => {
+    it('should get public card by share token without auth', async () => {
+      // public endpoint — no req.user needed
+      const req = buildReq({ user: undefined, params: { shareToken: 'tok-abc123def456' } });
+      mockCardService.getPublicCard.mockResolvedValue(mockCard);
+
+      await getPublicCard(req, res, next);
+
+      expect(mockCardService.getPublicCard).toHaveBeenCalledWith('tok-abc123def456');
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: expect.objectContaining({ id: 'card-123' }),
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should call next() with AppError 404 when public card not found', async () => {
+      const req = buildReq({ user: undefined, params: { shareToken: 'unknown' } });
+      mockCardService.getPublicCard.mockResolvedValue(null);
+
+      await getPublicCard(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(404);
+    });
+
+    it('should forward service errors to next()', async () => {
+      const req = buildReq({ params: { shareToken: 'tok' } });
+      mockCardService.getPublicCard.mockRejectedValue(new Error('boom'));
+
+      await getPublicCard(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getCardHistory', () => {
+    it('should get user card history with default pagination', async () => {
+      const req = buildReq({ query: {} });
+      mockCardService.getUserCards.mockResolvedValue([mockCard]);
+
+      await getCardHistory(req, res, next);
+
+      expect(mockCardService.getUserCards).toHaveBeenCalledWith(mockUser.id, 20, 0);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: { cards: [mockCard], limit: 20, offset: 0 },
+      });
+    });
+
+    it('should handle empty card history', async () => {
+      const req = buildReq({ query: {} });
+      mockCardService.getUserCards.mockResolvedValue([]);
+
+      await getCardHistory(req, res, next);
+
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: { cards: [], limit: 20, offset: 0 },
+      });
+    });
+
+    it('should enforce max limit of 50', async () => {
+      const req = buildReq({ query: { limit: '200', offset: '5' } });
+      mockCardService.getUserCards.mockResolvedValue([]);
+
+      await getCardHistory(req, res, next);
+
+      expect(mockCardService.getUserCards).toHaveBeenCalledWith(mockUser.id, 50, 5);
+    });
+
+    it('should forward service errors to next()', async () => {
+      const req = buildReq({ query: {} });
+      mockCardService.getUserCards.mockRejectedValue(new Error('fail'));
+
+      await getCardHistory(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('deleteCard', () => {
+    it('should delete a card successfully', async () => {
+      const req = buildReq({ params: { id: 'card-123' } });
+      mockCardService.deleteCard.mockResolvedValue(true);
+
+      await deleteCard(req, res, next);
+
+      expect(mockCardService.deleteCard).toHaveBeenCalledWith('card-123', mockUser.id);
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: { deleted: true } });
+    });
+
+    it('should call next() with AppError 404 when card not found', async () => {
+      const req = buildReq({ params: { id: 'nope' } });
+      mockCardService.deleteCard.mockResolvedValue(false);
+
+      await deleteCard(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(404);
+    });
+
+    it('should use user.id for authorization', async () => {
+      const req = buildReq({ params: { id: 'card-123' } });
+      mockCardService.deleteCard.mockResolvedValue(true);
+
+      await deleteCard(req, res, next);
+
+      expect(mockCardService.deleteCard).toHaveBeenCalledWith('card-123', mockUser.id);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getOgData', () => {
+    it('should return OG metadata for a valid share token', async () => {
+      const req = buildReq({ params: { shareToken: 'tok-abc123def456' } });
+      const og = { title: 'My Chart', description: 'Sun in Leo', image_url: 'https://cdn/x.png' };
+      mockCardService.getOgData.mockResolvedValue(og);
+
+      await getOgData(req, res, next);
+
+      expect(mockCardService.getOgData).toHaveBeenCalledWith('tok-abc123def456');
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: og });
+    });
+
+    it('should call next() with AppError 404 for unknown share token', async () => {
+      const req = buildReq({ params: { shareToken: 'unknown' } });
+      mockCardService.getOgData.mockResolvedValue(null);
+
+      await getOgData(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(404);
+    });
+  });
+});

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth, useCharts } from '../hooks';
 import { Link, NavLink, useLocation } from 'react-router-dom';
+import { SkipLink } from './SkipLink';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -12,12 +13,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   return (
     <div className="min-h-screen bg-cosmic-page">
       {/* WCAG 2.1 AA - Skip Navigation Link */}
-      <a
-        href="#main-content"
-        className="skip-link"
-      >
-        Skip to main content
-      </a>
+      <SkipLink target="#main-content">Skip to main content</SkipLink>
 
       {/* Mobile Sidebar Overlay */}
       {sidebarOpen && (

--- a/frontend/src/components/AuthLayout.tsx
+++ b/frontend/src/components/AuthLayout.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from 'react';
+import { SkipLink } from './SkipLink';
 
 interface AuthLayoutProps {
   children: ReactNode;
@@ -8,7 +9,7 @@ interface AuthLayoutProps {
 export function AuthLayout({ children, leftPanel }: AuthLayoutProps) {
   return (
     <div className="flex min-h-screen w-full flex-col lg:flex-row bg-cosmic-page">
-      <a href="#main-content" className="skip-link">Skip to main content</a>
+      <SkipLink target="#main-content">Skip to main content</SkipLink>
 
       {/* Left Panel — Brand & Artwork */}
       <div className="hidden lg:flex lg:w-5/12 xl:w-1/2 relative flex-col justify-between overflow-hidden bg-cosmic-page">

--- a/frontend/src/components/PublicPageLayout.tsx
+++ b/frontend/src/components/PublicPageLayout.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { SkipLink } from './SkipLink';
 
 interface PublicPageLayoutProps {
   children: React.ReactNode;
@@ -8,9 +9,7 @@ interface PublicPageLayoutProps {
 export function PublicPageLayout({ children, hideAuthLinks }: PublicPageLayoutProps) {
   return (
     <div className="min-h-screen bg-[var(--color-bg-page)]">
-      <a href="#main-content" className="skip-link">
-        Skip to main content
-      </a>
+      <SkipLink target="#main-content">Skip to main content</SkipLink>
 
       <main
         id="main-content"

--- a/frontend/src/components/SkipLink.tsx
+++ b/frontend/src/components/SkipLink.tsx
@@ -1,0 +1,22 @@
+/**
+ * SkipLink Component
+ *
+ * Provides an accessible skip-to-content link for keyboard navigation.
+ * Uses React Router's Link component for SPA navigation.
+ */
+
+import { Link } from 'react-router-dom';
+
+interface SkipLinkProps {
+  target: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SkipLink({ target, children, className = 'skip-link' }: SkipLinkProps) {
+  return (
+    <Link to={target} className={className}>
+      {children}
+    </Link>
+  );
+}

--- a/frontend/src/components/SkipLink.tsx
+++ b/frontend/src/components/SkipLink.tsx
@@ -2,7 +2,18 @@
  * SkipLink Component
  *
  * Provides an accessible skip-to-content link for keyboard navigation.
- * Uses React Router's Link component for SPA navigation.
+ *
+ * For in-page hash anchors (target starting with "#"), a plain <a> is rendered.
+ * This is intentional: an in-page skip link is a hash anchor, not client-side
+ * route navigation. Using React Router's <Link> for a hash target resolves it
+ * against the current route path (e.g. "/#main-content"), breaking both the
+ * `href` value and native browser focus behavior. Plain <a> preserves the
+ * expected `href="#main-content"` and the browser's built-in skip-to-anchor
+ * focus management.
+ *
+ * For path targets (e.g. "/dashboard"), React Router's <Link> is used for
+ * SPA navigation — satisfying the navigation convention that internal links
+ * must not use raw <a href> for route changes.
  */
 
 import { Link } from 'react-router-dom';
@@ -14,6 +25,16 @@ interface SkipLinkProps {
 }
 
 export function SkipLink({ target, children, className = 'skip-link' }: SkipLinkProps) {
+  // In-page hash anchors use a plain <a> to keep href="#..." semantics intact.
+  if (target.startsWith('#')) {
+    return (
+      <a href={target} className={className}>
+        {children}
+      </a>
+    );
+  }
+
+  // Path targets use React Router Link for SPA navigation.
   return (
     <Link to={target} className={className}>
       {children}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Helmet } from 'react-helmet-async';
+import { SkipLink } from '../components/SkipLink';
 export default function HomePage() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -18,7 +19,7 @@ export default function HomePage() {
         <meta name="description" content="Astrology SaaS platform for natal charts, transits, and cosmic insights." />
       </Helmet>
       {/* Skip to content */}
-      <a href="#main-content" className="skip-link">Skip to main content</a>
+      <SkipLink target="#main-content">Skip to main content</SkipLink>
 
       {/* ===== Navigation ===== */}
       <nav className="fixed top-0 w-full z-50 glass-nav transition-all duration-300">

--- a/frontend/src/pages/LoginPageNew.tsx
+++ b/frontend/src/pages/LoginPageNew.tsx
@@ -10,6 +10,7 @@ import { useNavigate, Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../hooks';
 import { Helmet } from 'react-helmet-async';
 import { wasDailyBriefingViewedToday } from '../utils/uiPreferences';
+import { SkipLink } from '../components/SkipLink';
 
 export default function LoginPageNew() {
   const navigate = useNavigate();
@@ -52,9 +53,7 @@ export default function LoginPageNew() {
         <title>Sign In — AstroVerse</title>
       </Helmet>
       {/* WCAG 2.1 AA - Skip Navigation Link */}
-      <a href="#main-content" className="skip-link">
-        Skip to main content
-      </a>
+      <SkipLink target="#main-content">Skip to main content</SkipLink>
       <main id="main-content">
         <div className="flex min-h-screen w-full flex-col lg:flex-row">
           {/* Left Panel: Cosmic Artwork */}


### PR DESCRIPTION
## Changes
- refactor(#431): Migrate 5 skip links to React Router navigation via new SkipLink component
- fix(#427,#428,#429): Add controller tests for ai, blog, and card controllers
- fix(#434): SkipLink hash-anchor regression — use plain `<a>` for `#` targets, `<Link>` for paths

## Issues Fixed
- #431: Raw `<a href>` skip links should use React Router navigation
- #427: Missing controller tests for ai.controller.ts
- #428: Missing controller tests for blog.controller.ts
- #429: Missing controller tests for card.controller.ts
- #434: SkipLink uses React Router Link for in-page hash anchors — breaks href

## Implementation Details

### Controller Tests (rewritten to match actual architecture)
The WIP tests assumed controllers `throw` to a rejection; the real conventions are:
- **ai.controller.ts**: plain async `(req, res)` functions — validated success via `res.json`, validation errors via `throw AppError`. Tests the real exports (`generateCompatibility`, `getUsageStats`, `clearCache`, etc.), not the non-existent `getAIUsage`/`resetAIUsage`/`generateSynastry`.
- **blog/card controllers**: wrapped in `asyncHandler()` (middleware-style `req,res,next`). Tests pass `mock next()` and assert `res.json` on success / `next(AppError)` on error.

### SkipLink Fix (#434)
The #431 refactor routed in-page hash anchors (`#main-content`) through React Router `<Link>`, resolving them against the current route path (`/#main-content`). This broke 2 accessibility tests. SkipLink now renders a plain `<a>` for hash targets and `<Link>` only for path targets.

## Verification
- ✅ Backend: **1667 tests pass** (76 suites) — `cd backend && npx jest`
- ✅ Frontend: **3887 tests pass** (143 files) — `cd frontend && npx vitest run`
- ✅ Backend typecheck (`tsc --noEmit`) + lint: 0 errors
- ✅ Frontend typecheck + lint: 0 errors

**Required CI Checks:** backend-test, frontend-test, Coverage Gate, TDD Enforcement