### PR TITLE
Deep Review: RelocationCalculator timezone bug + briefing asyncHandler + AI service AppError (#435 #436 #437)

### DIFF
--- a/backend/src/__tests__/controllers/briefing.controller.test.ts
+++ b/backend/src/__tests__/controllers/briefing.controller.test.ts
@@ -4,6 +4,8 @@
  *
  * Covers issue #358 (getBriefingByDate now queries by date, not "latest").
  * Also provides the missing controller coverage flagged in #355.
+ * Updated for asyncHandler wrapping (#436): errors are now forwarded via
+ * next() instead of being written directly to res.status().
  */
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -44,7 +46,7 @@ jest.mock('../../utils/logger', () => ({
 // Imports (after mocks are set up)
 // ---------------------------------------------------------------------------
 
-import { Response } from 'express';
+import { Response, NextFunction } from 'express';
 import { getBriefing, getBriefingByDate } from '../../modules/jobs/controllers/briefing.controller';
 
 // ---------------------------------------------------------------------------
@@ -78,6 +80,10 @@ function createMockResponse() {
   return res as Response;
 }
 
+function createMockNext(): NextFunction {
+  return jest.fn() as unknown as NextFunction;
+}
+
 const mockBriefing = {
   userId: 'user-123',
   date: '2026-04-08',
@@ -101,10 +107,12 @@ const mockContent = {
 
 describe('Briefing Controller', () => {
   let mockResponse: Partial<Response>;
+  let mockNext: NextFunction;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockResponse = createMockResponse();
+    mockNext = createMockNext();
     mockRegistry.formatBriefingContent!.mockReturnValue(mockContent);
   });
 
@@ -115,7 +123,7 @@ describe('Briefing Controller', () => {
     it('should return cached briefing when one exists for today', async () => {
       mockRegistry.getLatestBriefing!.mockResolvedValue(mockBriefing);
 
-      await getBriefing(createMockRequest() as any, mockResponse as Response);
+      await getBriefing(createMockRequest() as any, mockResponse as Response, mockNext);
 
       expect(mockResponse.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -131,7 +139,7 @@ describe('Briefing Controller', () => {
       mockRegistry.getLatestBriefing!.mockResolvedValue(null);
       mockRegistry.generateBriefing!.mockResolvedValue(mockBriefing);
 
-      await getBriefing(createMockRequest() as any, mockResponse as Response);
+      await getBriefing(createMockRequest() as any, mockResponse as Response, mockNext);
 
       expect(mockRegistry.generateBriefing).toHaveBeenCalledWith('user-123');
       expect(mockResponse.json).toHaveBeenCalledWith(
@@ -139,32 +147,33 @@ describe('Briefing Controller', () => {
       );
     });
 
-    it('should return 401 when user is not authenticated', async () => {
-      await getBriefing(createMockRequest({ user: undefined }) as any, mockResponse as Response);
+    it('should forward 401 via next() when user is not authenticated', async () => {
+      await getBriefing(createMockRequest({ user: undefined }) as any, mockResponse as Response, mockNext);
 
-      expect(mockResponse.status).toHaveBeenCalledWith(401);
-      expect(mockResponse.json).toHaveBeenCalledWith(
-        expect.objectContaining({ success: false }),
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 401 }),
       );
     });
 
-    it('should return 404 when generation fails with "No natal chart found"', async () => {
+    it('should forward 404 via next() when generation fails with "No natal chart found"', async () => {
       mockRegistry.getLatestBriefing!.mockResolvedValue(null);
       mockRegistry.generateBriefing!.mockRejectedValue(new Error('No natal chart found for user'));
 
-      await getBriefing(createMockRequest() as any, mockResponse as Response);
+      await getBriefing(createMockRequest() as any, mockResponse as Response, mockNext);
 
-      expect(mockResponse.status).toHaveBeenCalledWith(404);
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 404 }),
+      );
     });
 
-    it('should rethrow unexpected generation errors', async () => {
+    it('should forward unexpected generation errors via next()', async () => {
       mockRegistry.getLatestBriefing!.mockResolvedValue(null);
       const unexpected = new Error('DB down');
       mockRegistry.generateBriefing!.mockRejectedValue(unexpected);
 
-      await expect(
-        getBriefing(createMockRequest() as any, mockResponse as Response),
-      ).rejects.toThrow('DB down');
+      await getBriefing(createMockRequest() as any, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(unexpected);
     });
   });
 
@@ -178,6 +187,7 @@ describe('Briefing Controller', () => {
       await getBriefingByDate(
         createMockRequest({ params: { date: '2026-04-08' } }) as any,
         mockResponse as Response,
+        mockNext,
       );
 
       // CRITICAL: must call getBriefingByDate(userId, date), NOT getLatestBriefing(userId)
@@ -191,50 +201,56 @@ describe('Briefing Controller', () => {
       );
     });
 
-    it('should return 404 when no briefing exists for the date', async () => {
+    it('should forward 404 via next() when no briefing exists for the date', async () => {
       mockRegistry.getBriefingByDate!.mockResolvedValue(null);
 
       await getBriefingByDate(
         createMockRequest({ params: { date: '1999-01-01' } }) as any,
         mockResponse as Response,
+        mockNext,
       );
 
-      expect(mockResponse.status).toHaveBeenCalledWith(404);
-      expect(mockResponse.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          success: false,
-          error: expect.stringContaining('1999-01-01'),
-        }),
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 404 }),
       );
     });
 
-    it('should return 400 for an invalid date format', async () => {
+    it('should forward 400 via next() for an invalid date format', async () => {
       await getBriefingByDate(
         createMockRequest({ params: { date: '08-04-2026' } }) as any,
         mockResponse as Response,
+        mockNext,
       );
 
-      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 }),
+      );
       // Must NOT hit the DB on invalid input
       expect(mockRegistry.getBriefingByDate).not.toHaveBeenCalled();
     });
 
-    it('should return 400 for a malformed date (not YYYY-MM-DD)', async () => {
+    it('should forward 400 via next() for a malformed date (not YYYY-MM-DD)', async () => {
       await getBriefingByDate(
         createMockRequest({ params: { date: '2026-4-8' } }) as any,
         mockResponse as Response,
+        mockNext,
       );
 
-      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 }),
+      );
     });
 
-    it('should return 401 when user is not authenticated', async () => {
+    it('should forward 401 via next() when user is not authenticated', async () => {
       await getBriefingByDate(
         createMockRequest({ user: undefined, params: { date: '2026-04-08' } }) as any,
         mockResponse as Response,
+        mockNext,
       );
 
-      expect(mockResponse.status).toHaveBeenCalledWith(401);
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 401 }),
+      );
       expect(mockRegistry.getBriefingByDate).not.toHaveBeenCalled();
     });
   });

--- a/backend/src/modules/ai/services/aiInterpretation.service.ts
+++ b/backend/src/modules/ai/services/aiInterpretation.service.ts
@@ -13,6 +13,7 @@
  */
 
 import openaiService from './openai.service';
+import { AppError } from '../../../utils/appError';
 import type { ParsedInterpretation } from './openai.service';
 import aiCacheService from './aiCache.service';
 import { generateCompletePersonalityAnalysis } from '../../analysis/services/interpretation.service';
@@ -124,7 +125,7 @@ class AIInterpretationService {
           const aiResult = await openaiService.generateNatalInterpretation(chartData);
 
           if (!aiResult.success) {
-            throw new Error(aiResult.error || 'AI generation failed');
+            throw new AppError(aiResult.error || 'AI generation failed', 502);
           }
 
           // Combine with rule-based for comprehensive reading
@@ -173,7 +174,7 @@ class AIInterpretationService {
           const aiResult = await openaiService.generateTransitForecast(transitData);
 
           if (!aiResult.success) {
-            throw new Error(aiResult.error || 'AI generation failed');
+            throw new AppError(aiResult.error || 'AI generation failed', 502);
           }
 
           return {
@@ -212,7 +213,7 @@ class AIInterpretationService {
           const aiResult = await openaiService.generateCompatibilityAnalysis(synastryData);
 
           if (!aiResult.success) {
-            throw new Error(aiResult.error || 'AI generation failed');
+            throw new AppError(aiResult.error || 'AI generation failed', 502);
           }
 
           return {
@@ -255,7 +256,7 @@ class AIInterpretationService {
           const aiResult = await openaiService.generateLunarReturnInterpretation(chartData);
 
           if (!aiResult.success) {
-            throw new Error(aiResult.error || 'AI generation failed');
+            throw new AppError(aiResult.error || 'AI generation failed', 502);
           }
 
           return {
@@ -302,7 +303,7 @@ class AIInterpretationService {
           const aiResult = await openaiService.generateSolarReturnInterpretation(chartData);
 
           if (!aiResult.success) {
-            throw new Error(aiResult.error || 'AI generation failed');
+            throw new AppError(aiResult.error || 'AI generation failed', 502);
           }
 
           return {

--- a/backend/src/modules/ai/services/openai.service.ts
+++ b/backend/src/modules/ai/services/openai.service.ts
@@ -7,6 +7,7 @@ import OpenAI from 'openai';
 import { openaiConfig, PROMPT_TEMPLATES, INTERPRETATION_PARAMS } from '../config/openai.config';
 import logger from '../../../utils/logger';
 import aiUsageService from './aiUsage.service';
+import { AppError } from '../../../utils/appError';
 
 /**
  * Singleton OpenAI client instance — reused across requests
@@ -585,13 +586,13 @@ class OpenAIService {
    */
   private validateChartInput(data: NatalChartInput): void {
     if (!data || !data.planets || data.planets.length === 0) {
-      throw new Error('Chart data must include at least one planet position');
+      throw new AppError('Chart data must include at least one planet position', 400);
     }
 
     // Validate planet structure
     for (const planet of data.planets) {
       if (!planet.planet || !planet.sign || typeof planet.degree !== 'number' || typeof planet.house !== 'number') {
-        throw new Error('Invalid planet data structure');
+        throw new AppError('Invalid planet data structure', 400);
       }
     }
   }
@@ -601,7 +602,7 @@ class OpenAIService {
    */
   private validateTransitInput(data: TransitInput): void {
     if (!data || !data.currentTransits || data.currentTransits.length === 0) {
-      throw new Error('Transit data must include at least one transit event');
+      throw new AppError('Transit data must include at least one transit event', 400);
     }
 
     for (const transit of data.currentTransits) {
@@ -612,7 +613,7 @@ class OpenAIService {
         !transit.startDate ||
         !transit.endDate
       ) {
-        throw new Error('Invalid transit data structure');
+        throw new AppError('Invalid transit data structure', 400);
       }
     }
   }
@@ -622,7 +623,7 @@ class OpenAIService {
    */
   private validateSynastryInput(data: SynastryInput): void {
     if (!data || !data.chartA || !data.chartB) {
-      throw new Error('Synastry data must include both charts');
+      throw new AppError('Synastry data must include both charts', 400);
     }
 
     this.validateChartInput(data.chartA);

--- a/backend/src/modules/jobs/controllers/briefing.controller.ts
+++ b/backend/src/modules/jobs/controllers/briefing.controller.ts
@@ -7,6 +7,8 @@
 
 import { Response } from 'express';
 import { AuthenticatedRequest } from '../../../middleware/auth';
+import { asyncHandler } from '../../../middleware/errorHandler';
+import { AppError } from '../../../utils/appError';
 import {
   getLatestBriefing,
   getBriefingByDate as fetchBriefingByDate,
@@ -19,18 +21,78 @@ import {
  * Get the latest daily briefing for the authenticated user.
  * If no briefing exists for today, generates one on-the-fly.
  */
-export async function getBriefing(req: AuthenticatedRequest, res: Response): Promise<void> {
-  const userId = req.user?.id;
+export const getBriefing = asyncHandler(
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const userId = req.user?.id;
 
-  if (!userId) {
-    res.status(401).json({ success: false, error: 'Authentication required' });
-    return;
-  }
+    if (!userId) {
+      throw new AppError('Authentication required', 401);
+    }
 
-  // Try to fetch today's briefing from DB first
-  const briefing = await getLatestBriefing(userId);
+    // Try to fetch today's briefing from DB first
+    const briefing = await getLatestBriefing(userId);
 
-  if (briefing) {
+    if (briefing) {
+      const content = formatBriefingContent(briefing);
+      res.json({
+        success: true,
+        data: {
+          briefing,
+          content,
+        },
+      });
+      return;
+    }
+
+    // No briefing found — generate one on-the-fly
+    try {
+      const newBriefing = await generateBriefing(userId);
+      const content = formatBriefingContent(newBriefing);
+
+      res.json({
+        success: true,
+        data: {
+          briefing: newBriefing,
+          content,
+        },
+      });
+    } catch (err) {
+      const message = (err as Error).message;
+      if (message.includes('No natal chart found')) {
+        throw new AppError(
+          'No natal chart found. Please create a natal chart first to receive daily briefings.',
+          404,
+        );
+      }
+      throw err;
+    }
+  },
+);
+
+/**
+ * GET /api/v1/briefing/:date
+ * Get a briefing for a specific date (history lookup)
+ */
+export const getBriefingByDate = asyncHandler(
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const userId = req.user?.id;
+    const { date } = req.params;
+
+    if (!userId) {
+      throw new AppError('Authentication required', 401);
+    }
+
+    // Validate date format
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw new AppError('Invalid date format. Use YYYY-MM-DD.', 400);
+    }
+
+    const briefing = await fetchBriefingByDate(userId, date);
+
+    if (!briefing) {
+      throw new AppError(`No briefing found for ${date}`, 404);
+    }
+
     const content = formatBriefingContent(briefing);
     res.json({
       success: true,
@@ -39,67 +101,5 @@ export async function getBriefing(req: AuthenticatedRequest, res: Response): Pro
         content,
       },
     });
-    return;
-  }
-
-  // No briefing found — generate one on-the-fly
-  try {
-    const newBriefing = await generateBriefing(userId);
-    const content = formatBriefingContent(newBriefing);
-
-    res.json({
-      success: true,
-      data: {
-        briefing: newBriefing,
-        content,
-      },
-    });
-  } catch (err) {
-    const message = (err as Error).message;
-    if (message.includes('No natal chart found')) {
-      res.status(404).json({
-        success: false,
-        error:
-          'No natal chart found. Please create a natal chart first to receive daily briefings.',
-      });
-      return;
-    }
-    throw err;
-  }
-}
-
-/**
- * GET /api/v1/briefing/:date
- * Get a briefing for a specific date (history lookup)
- */
-export async function getBriefingByDate(req: AuthenticatedRequest, res: Response): Promise<void> {
-  const userId = req.user?.id;
-  const { date } = req.params;
-
-  if (!userId) {
-    res.status(401).json({ success: false, error: 'Authentication required' });
-    return;
-  }
-
-  // Validate date format
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    res.status(400).json({ success: false, error: 'Invalid date format. Use YYYY-MM-DD.' });
-    return;
-  }
-
-  const briefing = await fetchBriefingByDate(userId, date);
-
-  if (!briefing) {
-    res.status(404).json({ success: false, error: `No briefing found for ${date}` });
-    return;
-  }
-
-  const content = formatBriefingContent(briefing);
-  res.json({
-    success: true,
-    data: {
-      briefing,
-      content,
-    },
-  });
-}
+  },
+);

--- a/backend/src/modules/jobs/routes/briefing.routes.ts
+++ b/backend/src/modules/jobs/routes/briefing.routes.ts
@@ -5,7 +5,7 @@
  * CHI-68: In-app briefing page accessible from dashboard
  */
 
-import { Router, RequestHandler } from 'express';
+import { Router } from 'express';
 import { authenticate } from '../../../middleware/auth';
 import { validateParams, dateParamSchema } from '../../../utils/validators';
 import { getBriefing, getBriefingByDate } from '../controllers/briefing.controller';
@@ -29,7 +29,7 @@ router.use(authenticate);
  *       200:
  *         description: Daily briefing data
  */
-router.get('/', getBriefing as RequestHandler);
+router.get('/', getBriefing);
 
 /**
  * @route   GET /api/v1/briefing/:date
@@ -53,6 +53,6 @@ router.get('/', getBriefing as RequestHandler);
  *       400:
  *         description: Invalid date format
  */
-router.get('/:date', validateParams(dateParamSchema), getBriefingByDate as RequestHandler);
+router.get('/:date', validateParams(dateParamSchema), getBriefingByDate);
 
 export { router as briefingRoutes };

--- a/frontend/src/components/RelocationCalculator.tsx
+++ b/frontend/src/components/RelocationCalculator.tsx
@@ -121,14 +121,36 @@ export const RelocationCalculator: React.FC<RelocationCalculatorProps> = ({
         address?: { country?: string; state?: string };
       }[] = await response.json();
 
-      const mapped: Location[] = results.map((r) => ({
-        name: r.display_name.split(',').slice(0, 2).join(','),
-        latitude: parseFloat(r.lat),
-        longitude: parseFloat(r.lon),
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone, // best-effort
-        country: r.address?.country,
-        region: r.address?.state,
-      }));
+      // Fetch the timezone for each result location via Open-Meteo timezone API.
+      // Previously this used the browser's local timezone (Intl.DateTimeFormat),
+      // which is wrong — a user in New York searching for "Tokyo" would get
+      // "America/New_York" instead of "Asia/Tokyo". See issue #435.
+      const mapped: Location[] = await Promise.all(
+        results.map(async (r) => {
+          const latitude = parseFloat(r.lat);
+          const longitude = parseFloat(r.lon);
+          let timezone = 'UTC';
+          try {
+            const tzResponse = await fetch(
+              `https://timezone-api.open-meteo.com/v1/timezone?latitude=${latitude}&longitude=${longitude}`,
+            );
+            if (tzResponse.ok) {
+              const tzData = (await tzResponse.json()) as { timezone?: string };
+              timezone = tzData.timezone ?? 'UTC';
+            }
+          } catch {
+            // Fall back to UTC if timezone lookup fails
+          }
+          return {
+            name: r.display_name.split(',').slice(0, 2).join(','),
+            latitude,
+            longitude,
+            timezone,
+            country: r.address?.country,
+            region: r.address?.state,
+          };
+        }),
+      );
 
       setLocations(mapped);
     } catch {


### PR DESCRIPTION
## Changes

### fix(#435): RelocationCalculator timezone bug
- `frontend/src/components/RelocationCalculator.tsx` used `Intl.DateTimeFormat().resolvedOptions().timeZone` which returns the **browser's** timezone, not the searched location's timezone
- A user in New York searching for "Tokyo" would get `America/New_York` instead of `Asia/Tokyo`
- This caused **incorrect relocation chart calculations** (the entire purpose of the feature)
- **Fix**: Now fetches timezone via Open-Meteo timezone API (consistent with `location.service.ts`)

### fix(#436): Briefing controller missing asyncHandler
- `backend/src/modules/jobs/controllers/briefing.controller.ts` exported `async function` handlers without `asyncHandler` wrapping
- Express 4 does NOT automatically catch rejected promises from async route handlers
- DB errors in `getLatestBriefing()` (not in try/catch) would cause **unhandled promise rejections** and request hangs
- **Fix**: Wrapped with `asyncHandler` (consistent with all other controllers). Migrated direct `res.status()` calls to `AppError` throws. Updated 7 tests.

### refactor(#437): AI services `throw new Error` → `AppError`
- `openai.service.ts`: 5 validation errors changed from `throw new Error` → `throw new AppError(..., 400)` (Bad Request)
- `aiInterpretation.service.ts`: 5 AI generation failures changed from `throw new Error` → `throw new AppError(..., 502)` (Bad Gateway)
- Previously these returned HTTP 500 (Internal Server Error) for client input validation errors

## Test Results
- ✅ Backend TypeScript: clean (`tsc --noEmit`)
- ✅ Frontend TypeScript: clean (`tsc --noEmit`)
- ✅ Briefing controller tests: 10/10 pass
- ✅ AI service tests: 21/21 pass (openai + aiInterpretation)
- ✅ All AI tests: 172/172 pass
- ✅ All controller/service/route tests: 1096/1096 pass

## Issues Resolved
- Closes #435
- Closes #436
- Closes #437

**Required CI:** backend-test, frontend-test, 📊 Coverage Must Not Decrease, 🧪 Tests Required for Changes
