### PR TITLE
Deep Review: Import convention fix + route naming + computation rate limiting

### DIFF
--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -234,6 +234,28 @@ export const cardGenerationRateLimiter = rateLimit({
   },
 });
 
+/**
+ * Rate limiter for astronomical computation endpoints (synastry, solar return,
+ * lunar return, transit calculations, personality analysis).
+ * These are CPU-intensive and require ephemeris data processing.
+ */
+export const astroComputationRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: process.env.NODE_ENV !== 'production' ? 100 : 20,
+  message: {
+    success: false,
+    error: 'Too many computation requests. Please try again later.',
+    code: 'RATE_LIMIT_ASTRO_COMPUTATION',
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => {
+    const userId = req.user?.id;
+    const ip = req.ip || req.connection.remoteAddress || 'unknown';
+    return userId ? `astro-calc:${userId}` : `astro-calc:${ip}`;
+  },
+});
+
 export default {
   pdf: pdfRateLimiter,
   share: shareRateLimiter,

--- a/backend/src/modules/analysis/routes/analysis.routes.ts
+++ b/backend/src/modules/analysis/routes/analysis.routes.ts
@@ -6,6 +6,7 @@ import { Router } from 'express';
 import { authenticate, AuthenticatedRequest } from '../../../middleware/auth';
 import { asyncHandler } from '../../../middleware/errorHandler';
 import { validateParams } from '../../../utils/validators';
+import { astroComputationRateLimiter } from '../../../middleware/rateLimiter';
 import { z } from 'zod';
 import * as AnalysisController from '../controllers/analysis.controller';
 
@@ -17,6 +18,7 @@ const router = Router();
 
 // All analysis routes require authentication
 router.use(authenticate);
+router.use(astroComputationRateLimiter);
 
 /**
  * @openapi

--- a/backend/src/modules/jobs/services/dailyBriefing.service.ts
+++ b/backend/src/modules/jobs/services/dailyBriefing.service.ts
@@ -12,7 +12,7 @@
 
 import logger from '../../../utils/logger';
 import { calculateMoonPhase } from '../../calendar/services/calendar.service';
-import AstronomyEngineService from '../../shared/services/astronomyEngine.service';
+import { AstronomyEngineService } from '../../shared/services/astronomyEngine.service';
 import { capitalize } from '../../../shared/utils/stringUtils';
 import { NotFoundError } from '../../../utils/appError';
 

--- a/backend/src/modules/lunar/routes/lunarReturn.routes.ts
+++ b/backend/src/modules/lunar/routes/lunarReturn.routes.ts
@@ -7,6 +7,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import * as lunarReturnController from '../controllers/lunarReturn.controller';
 import { authenticate } from '../../../middleware/auth';
+import { astroComputationRateLimiter } from '../../../middleware/rateLimiter';
 import {
   validateBody,
   validateQuery,
@@ -92,6 +93,7 @@ router.get('/current', lunarReturnController.getCurrentLunarReturn);
  */
 router.post(
   '/chart',
+  astroComputationRateLimiter,
   validateBody(lunarReturnChartSchema),
   lunarReturnController.getLunarReturnChart,
 );
@@ -121,6 +123,7 @@ router.post(
  */
 router.post(
   '/forecast',
+  astroComputationRateLimiter,
   validateBody(lunarForecastSchema),
   lunarReturnController.getLunarMonthForecast,
 );
@@ -205,6 +208,7 @@ router.delete('/:id', validateParams(uuidParamSchema), lunarReturnController.del
  */
 router.post(
   '/calculate',
+  astroComputationRateLimiter,
   validateBody(lunarCalculateSchema),
   lunarReturnController.calculateCustomLunarReturn,
 );

--- a/backend/src/modules/notifications/index.ts
+++ b/backend/src/modules/notifications/index.ts
@@ -6,4 +6,4 @@
 export { default as pushNotificationService } from './services/pushNotification.service';
 export { default as pushSubscriptionModel } from './models/pushSubscription.model';
 export * from './controllers/pushNotification.controller';
-export { PushNotificationRoutes as pushNotificationRoutes } from './routes/pushNotification.routes';
+export { pushNotificationRoutes } from './routes/pushNotification.routes';

--- a/backend/src/modules/notifications/routes/pushNotification.routes.ts
+++ b/backend/src/modules/notifications/routes/pushNotification.routes.ts
@@ -2,7 +2,7 @@
  * Push Notification Routes
  */
 
-import express from 'express';
+import { Router } from 'express';
 import {
   saveSubscription,
   deleteSubscription,
@@ -26,7 +26,7 @@ const pushSubscriptionSchema = z.object({
   }),
 }).strict();
 
-const router = express.Router();
+const router = Router();
 
 /**
  * @route   GET /api/v1/notifications/vapid-key
@@ -132,4 +132,4 @@ router.get('/subscriptions', getSubscriptions);
  */
 router.post('/test', sendTestNotification);
 
-export { router as PushNotificationRoutes };
+export { router as pushNotificationRoutes };

--- a/backend/src/modules/solar/routes/solarReturn.routes.ts
+++ b/backend/src/modules/solar/routes/solarReturn.routes.ts
@@ -15,6 +15,7 @@ import {
   deleteSolarReturn,
 } from '../controllers/solarReturn.controller';
 import { authenticate } from '../../../middleware/auth';
+import { astroComputationRateLimiter } from '../../../middleware/rateLimiter';
 import { validateBody, validateParams, validateQuery, uuidParamSchema, solarHistoryQuerySchema } from '../../../utils/validators';
 import { z } from 'zod';
 
@@ -97,6 +98,7 @@ router.use(authenticate);
  */
 router.post(
   '/calculate',
+  astroComputationRateLimiter,
   validateBody(calculateSchema),
   calculateSolarReturn
 );
@@ -263,6 +265,7 @@ router.get(
  */
 router.post(
   '/:id/recalculate',
+  astroComputationRateLimiter,
   validateBody(recalculateSchema),
   recalculateSolarReturn
 );

--- a/backend/src/modules/synastry/routes/synastry.routes.ts
+++ b/backend/src/modules/synastry/routes/synastry.routes.ts
@@ -7,6 +7,7 @@ import { Router, RequestHandler } from 'express';
 import { z } from 'zod';
 import * as synastryController from '../controllers/synastry.controller';
 import { authenticate } from '../../../middleware/auth';
+import { astroComputationRateLimiter } from '../../../middleware/rateLimiter';
 import {
   validateBody,
   validateQuery,
@@ -67,6 +68,7 @@ const updateReportSchema = z.object({
  */
 router.post(
   '/compare',
+  astroComputationRateLimiter,
   validateBody(compareSchema),
   synastryController.compareCharts as RequestHandler,
 );
@@ -104,6 +106,7 @@ router.post(
  */
 router.post(
   '/compatibility',
+  astroComputationRateLimiter,
   validateBody(compatibilitySchema),
   synastryController.getCompatibility as RequestHandler,
 );

--- a/backend/src/modules/transits/routes/transit.routes.ts
+++ b/backend/src/modules/transits/routes/transit.routes.ts
@@ -4,6 +4,7 @@
 
 import { Router } from 'express';
 import { authenticate, optionalAuthenticate, AuthenticatedRequest } from '../../../middleware/auth';
+import { astroComputationRateLimiter } from '../../../middleware/rateLimiter';
 import { asyncHandler } from '../../../middleware/errorHandler';
 import { validateBody, validateParams, validateQuery, uuidParamSchema } from '../../../utils/validators';
 import { calculateTransitsSchema, transitCalendarQuerySchema, transitForecastQuerySchema } from '../../../utils/validators';
@@ -80,6 +81,7 @@ router.use(authenticate);
  */
 router.post(
   '/calculate',
+  astroComputationRateLimiter,
   validateBody(calculateTransitsSchema),
   asyncHandler(async (req, res) => {
     await TransitController.calculateTransits(req as AuthenticatedRequest, res);


### PR DESCRIPTION
## Summary

Fixes #497, #498, #499 — three issues found during deep code quality review.

## Changes

### fix(#497): dailyBriefing.service.ts import convention
- Changed `import AstronomyEngineService default` → `import { AstronomyEngineService }` (named import)
- Aligns with convention used by all other 4 modules that import AstronomyEngineService

### fix(#498): pushNotification.routes.ts standardization
- Changed `import express from 'express'` → `import { Router } from 'express'` (named import)
- Changed `express.Router()` → `Router()`
- Renamed route export `PushNotificationRoutes` → `pushNotificationRoutes` (camelCase)
- Updated barrel `modules/notifications/index.ts` to re-export directly

### fix(#499): Computation rate limiting
- Added `astroComputationRateLimiter` (20 req/15min production, 100/15min dev) to `middleware/rateLimiter.ts`
- Applied to all computation-heavy POST endpoints:
  - `analysis.routes.ts`: all GET endpoints (personality, aspects, patterns, planets, houses)
  - `synastry.routes.ts`: POST /compare, /compatibility
  - `solarReturn.routes.ts`: POST /calculate, /:id/recalculate
  - `lunarReturn.routes.ts`: POST /chart, /forecast, /calculate
  - `transit.routes.ts`: POST /calculate

## Verification
- ✅ ESLint passes on all modified files
- ✅ TypeScript typecheck passes (`tsc --noEmit` clean)

**Required CI:** backend-test, frontend-test, Coverage, TDD
