### PR TITLE
ci: Add auto-merge workflow for auto-review PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,40 @@
+name: Auto-Merge Passing PRs
+
+on:
+  check_suite:
+    types: [completed]
+  pull_request:
+    types: [synchronize, opened, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.sender.login == 'xarlord' ||
+      contains(github.event.pull_request.head.ref, 'auto-review')
+    steps:
+      - name: Wait for required checks
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+          running-workflow-name: auto-merge
+
+      - name: Auto-merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHECKS=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-runs --jq '.check_runs[] | select(.name == "build-and-test" or .name == "lint" or .name == "TDD" or .name == "Unit Tests" or .name == "Kotlin Linting" or .name == "Android Lint" or .name == "build" or .name == "test" or .name == "Security Checklist" or .name == "Documentation Check")')
+          FAILED=$(echo "$CHECKS" | jq -r '[.[] | select(.conclusion == "FAILURE")] | length')
+          PENDING=$(echo "$CHECKS" | jq -r '[.[] | select(.status != "completed")] | length')
+          if [ "$FAILED" -gt 0 ] || [ "$PENDING" -gt 0 ]; then
+            echo "::notice::Skipping auto-merge: $FAILED failures, $PENDING pending"
+            exit 0
+          fi
+          echo "::notice::All checks passed, merging PR #${{ github.event.pull_request.number }}"
+          gh pr merge ${{ github.event.pull_request.number }} --squash --admin || true


### PR DESCRIPTION
Adds an auto-merge workflow that automatically merges passing PRs from auto-review branches.

- Triggers on check_suite completion and PR events
- Only acts on PRs by xarlord or with 'auto-review' in branch name
- Waits for all required checks before merging
- Skips merge if any checks fail or are pending
- Uses squash merge with admin override