### PR TITLE
fix(#489): Use getErrorMessage in authStore for user-friendly API errors

### DIFF
--- a/frontend/src/__tests__/stores/authStore.test.ts
+++ b/frontend/src/__tests__/stores/authStore.test.ts
@@ -151,7 +151,10 @@ describe('authStore', () => {
 
     it('should handle login error', async () => {
       const errorMessage = 'Invalid credentials';
-      vi.mocked(authService.login).mockRejectedValueOnce(new Error(errorMessage));
+      vi.mocked(authService.login).mockRejectedValueOnce({
+        response: { data: { error: errorMessage } },
+        message: 'Request failed with status code 401',
+      });
 
       await act(async () => {
         try {
@@ -229,7 +232,10 @@ describe('authStore', () => {
 
     it('should handle register error', async () => {
       const errorMessage = 'Email already exists';
-      vi.mocked(authService.register).mockRejectedValueOnce(new Error(errorMessage));
+      vi.mocked(authService.register).mockRejectedValueOnce({
+        response: { data: { error: errorMessage } },
+        message: 'Request failed with status code 409',
+      });
 
       await act(async () => {
         try {
@@ -392,7 +398,10 @@ describe('authStore', () => {
     });
 
     it('should handle profile update error', async () => {
-      vi.mocked(authService.updateProfile).mockRejectedValueOnce(new Error('Update failed'));
+      vi.mocked(authService.updateProfile).mockRejectedValueOnce({
+        response: { data: { error: 'Update failed' } },
+        message: 'Request failed with status code 400',
+      });
 
       await act(async () => {
         try {
@@ -428,9 +437,10 @@ describe('authStore', () => {
     });
 
     it('should handle preferences update error', async () => {
-      vi.mocked(authService.updatePreferences).mockRejectedValueOnce(
-        new Error('Preferences error'),
-      );
+      vi.mocked(authService.updatePreferences).mockRejectedValueOnce({
+        response: { data: { error: 'Preferences error' } },
+        message: 'Request failed with status code 400',
+      });
 
       await act(async () => {
         try {

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -7,6 +7,7 @@ import { persist, devtools } from 'zustand/middleware';
 import { authService } from '../services';
 import { getAccessToken } from '../utils/tokenStorage';
 import { clearCsrfToken } from '../services/api';
+import { getErrorMessage } from '../utils/errorHandling';
 import type { User, LoginCredentials, RegisterData } from '../services/api.types';
 
 interface AuthState {
@@ -52,7 +53,7 @@ export const useAuthStore = create<AuthState>()(
             });
           } catch (error: unknown) {
             set({
-              error: error instanceof Error ? error.message : 'Login failed',
+              error: getErrorMessage(error, 'Login failed'),
               isLoading: false,
               isAuthenticated: false,
             });
@@ -75,7 +76,7 @@ export const useAuthStore = create<AuthState>()(
             });
           } catch (error: unknown) {
             set({
-              error: error instanceof Error ? error.message : 'Registration failed',
+              error: getErrorMessage(error, 'Registration failed'),
               isLoading: false,
               isAuthenticated: false,
             });
@@ -151,7 +152,7 @@ export const useAuthStore = create<AuthState>()(
             });
           } catch (error: unknown) {
             set({
-              error: error instanceof Error ? error.message : 'Profile update failed',
+              error: getErrorMessage(error, 'Profile update failed'),
               isLoading: false,
             });
             throw error;
@@ -168,7 +169,7 @@ export const useAuthStore = create<AuthState>()(
             });
           } catch (error: unknown) {
             set({
-              error: error instanceof Error ? error.message : 'Preferences update failed',
+              error: getErrorMessage(error, 'Preferences update failed'),
               isLoading: false,
             });
             throw error;


### PR DESCRIPTION
## Problem
When the backend returns a 429 (rate limit) or any other error, the frontend displays the raw Axios error message (e.g. 'Request failed with status code 429') instead of the backend's user-friendly message (e.g. 'Too many authentication attempts. Please try again later.').

## Root Cause
authStore.ts used `error instanceof Error ? error.message` which returns the generic Axios error message, not the backend's response body.

## Fix
- Import `getErrorMessage` utility which extracts the error message from `response.data.error`
- Replace all 4 `error.message` fallbacks in authStore (login, register, updateProfile, updatePreferences)
- Update 4 tests to use Axios-like error shapes that match real API responses

## Testing
- All 26 authStore tests pass
- Full frontend suite: 3887 tests pass
- TypeScript: clean
- ESLint: 0 errors

Closes #489