### PR TITLE
fix: prevent SVG chart wheel horizontal overflow on mobile (#511)

### DIFF
--- a/frontend/src/components/ChartWheel.tsx
+++ b/frontend/src/components/ChartWheel.tsx
@@ -177,7 +177,7 @@ export function ChartWheel({
       <svg
         role="img" aria-label={`Natal chart wheel with ${planets.length} planets`}
         data-testid="chart-wheel"
-        viewBox={`0 0 ${totalSize} ${totalSize}`} className="w-full h-auto"
+        viewBox={`0 0 ${totalSize} ${totalSize}`} className="w-full h-auto max-w-full overflow-hidden"
         style={{ fontFamily: 'system-ui, sans-serif' }}
       >
         <defs>

--- a/frontend/src/pages/ChartViewPage.tsx
+++ b/frontend/src/pages/ChartViewPage.tsx
@@ -278,7 +278,7 @@ export default function ChartViewPage() {
         <>
           <div className="grid lg:grid-cols-2 gap-8">
             {/* Chart Wheel */}
-            <div className="bg-cosmic-card-solid border border-white/15 rounded-2xl p-2">
+            <div className="bg-cosmic-card-solid border border-white/15 rounded-2xl p-2 overflow-hidden">
               <ChartWheel data={chartData} interactive={true} />
               <ChartWheelLegend />
             </div>


### PR DESCRIPTION
## Summary
Fixes #511 — Natal chart SVG wheel causing 20px horizontal overflow on mobile (375px viewport).

## Changes
- **ChartWheel.tsx**: Added max-w-full overflow-hidden to SVG element to prevent text labels from extending beyond the viewBox boundary
- **ChartViewPage.tsx**: Added overflow-hidden to the chart wheel container div as a secondary containment measure

## Testing
- All 30 ChartWheel tests pass
- All 18 ChartViewPage tests pass
- Full frontend suite: 3887 tests pass
- Full backend suite: 1667 tests pass

## Root Cause
SVG text elements for planet labels have unconstrained widths (scrollWidth 552px, 664px, 399px) extending beyond 375px viewport. The overflow hidden CSS on the SVG clips any content beyond the viewBox boundary while maintaining the w-full h-auto responsive sizing.

## Visual Impact
- No change on desktop (SVG already fits within viewport)
- Mobile: horizontal scrollbar eliminated, content clipped cleanly at viewport edge