### PR TITLE
fix: correct password strength feedback DOM nesting

### DIFF
--- a/frontend/src/pages/RegisterPageNew.tsx
+++ b/frontend/src/pages/RegisterPageNew.tsx
@@ -342,19 +342,19 @@ export default function RegisterPageNew() {
                         />
                       ))}
                     </div>
-                    <p className="text-xs text-slate-500 px-1 flex items-center gap-2">
+                    <div className="text-xs text-slate-500 px-1 flex items-center gap-2">
                       {passwordStrength.label && (
                         <>
                           <span
                             className={`inline-block w-2 h-2 rounded-full ${passwordStrength.color}`}
                           ></span>
-                          Password strength: {passwordStrength.label}
-                          {password && password.length < 12 && (
-                            <p className="text-xs text-slate-400 mt-0.5">Min 12 chars: uppercase, lowercase, number, special (@$!%*?&)</p>
+                          <span>Password strength: {passwordStrength.label}</span>
+                          {password.length < 12 && (
+                            <span className="text-slate-400 mt-0.5">Min 12 chars: uppercase, lowercase, number, special (@$!%*?&)</span>
                           )}
                         </>
                       )}
-                    </p>
+                    </div>
                   </>
                 )}
               </div>


### PR DESCRIPTION
## Summary
Corrects invalid HTML in the registration password-strength feedback: a paragraph was nested inside another paragraph, which caused React `validateDOMNesting` warnings and can lead browsers to repair the DOM inconsistently.

## Changes
- Use semantic-neutral `div`/`span` elements for the inline password-strength status and helper text.
- Preserve all existing visual styling and feedback content.

## Validation
- `cd frontend && npx vitest run src/__tests__/pages/RegisterPageNew.test.tsx` — 47 passed
- `cd frontend && npx tsc --noEmit` — passed