### PR TITLE
fix: correct PWA banner layout and navigation landmarks (#514)

### DIFF
--- a/frontend/src/__tests__/components/ServiceWorkerUpdateBanner.test.tsx
+++ b/frontend/src/__tests__/components/ServiceWorkerUpdateBanner.test.tsx
@@ -140,6 +140,21 @@ describe('ServiceWorkerUpdateBanner', () => {
     expect(banner).toHaveClass('fixed');
   });
 
+  it('keeps the update banner constrained to a centered card on larger screens', () => {
+    vi.mocked(useServiceWorkerUpdate).mockReturnValue({
+      needRefresh: true,
+      offlineReady: false,
+      update: vi.fn(),
+      skipWaiting: vi.fn(),
+    });
+
+    const { container } = render(<ServiceWorkerUpdateBanner />);
+    const banner = container.querySelector('.fixed');
+
+    expect(banner).toHaveClass('w-full', 'max-w-full', 'sm:w-[400px]', 'sm:max-w-[90%]');
+    expect(banner).not.toHaveClass('sm:left-0', 'sm:right-0', 'sm:w-full', 'sm:max-w-full');
+  });
+
   it('should render offline banner with offline-specific styling', () => {
     vi.mocked(useServiceWorkerUpdate).mockReturnValue({
       needRefresh: false,

--- a/frontend/src/__tests__/pages/HomePage.test.tsx
+++ b/frontend/src/__tests__/pages/HomePage.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter } from 'react-router-dom';
+import HomePage from '../../pages/HomePage';
+
+describe('HomePage', () => {
+  it('exposes the primary navigation inside a header landmark', () => {
+    render(
+      <HelmetProvider>
+        <MemoryRouter>
+          <HomePage />
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+
+    const header = screen.getByRole('banner');
+    expect(header).toContainElement(screen.getByRole('navigation'));
+  });
+});

--- a/frontend/src/components/ServiceWorkerUpdateBanner.tsx
+++ b/frontend/src/components/ServiceWorkerUpdateBanner.tsx
@@ -30,7 +30,7 @@ export const ServiceWorkerUpdateBanner: React.FC = () => {
 
   if (offlineReady) {
     return (
-      <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-sw-banner max-w-[90%] w-[400px] bg-[#423d0f] border border-[#ca8a04] rounded-xl shadow-[0_4px_20px_rgba(0,0,0,0.4)] px-5 py-4 animate-slide-up sm:bottom-0 sm:left-0 sm:right-0 sm:translate-none sm:w-full sm:max-w-full sm:rounded-b-none sm:rounded-t-xl sm:animate-slide-up-mobile">
+      <div className="fixed bottom-0 left-0 right-0 z-sw-banner w-full max-w-full bg-[#423d0f] border border-[#ca8a04] rounded-b-none rounded-t-xl shadow-[0_4px_20px_rgba(0,0,0,0.4)] px-5 py-4 animate-slide-up sm:bottom-5 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 sm:w-[400px] sm:max-w-[90%] sm:rounded-xl">
         <div className="flex items-center gap-3">
           <span className="text-2xl leading-none shrink-0">📶</span>
           <div className="flex-1 flex flex-col gap-0.5">
@@ -47,7 +47,7 @@ export const ServiceWorkerUpdateBanner: React.FC = () => {
   }
 
   return (
-    <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-sw-banner max-w-[90%] w-[400px] bg-cosmic-card/90 backdrop-blur-md border border-white/15 rounded-xl shadow-[0_4px_20px_rgba(0,0,0,0.4)] px-5 py-4 animate-slide-up sm:bottom-0 sm:left-0 sm:right-0 sm:translate-none sm:w-full sm:max-w-full sm:rounded-b-none sm:rounded-t-xl sm:animate-slide-up-mobile">
+    <div className="fixed bottom-0 left-0 right-0 z-sw-banner w-full max-w-full bg-cosmic-card/90 backdrop-blur-md border border-white/15 rounded-b-none rounded-t-xl shadow-[0_4px_20px_rgba(0,0,0,0.4)] px-5 py-4 animate-slide-up sm:bottom-5 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 sm:w-[400px] sm:max-w-[90%] sm:rounded-xl">
       <div className="flex items-center gap-3 sm:flex-row sm:flex-wrap">
         <span className="text-2xl leading-none shrink-0">🔄</span>
         <div className="flex-1 sm:min-w-0">

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -22,7 +22,8 @@ export default function HomePage() {
       <SkipLink target="#main-content">Skip to main content</SkipLink>
 
       {/* ===== Navigation ===== */}
-      <nav className="fixed top-0 w-full z-50 glass-nav transition-all duration-300">
+      <header>
+        <nav className="fixed top-0 w-full z-50 glass-nav transition-all duration-300">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-20">
             {/* Logo */}
@@ -64,9 +65,8 @@ export default function HomePage() {
             </div>
           </div>
         </div>
-      </nav>
-
-      {/* Mobile Menu Overlay */}
+        </nav>
+      </header>
       {mobileMenuOpen && (
         <div
           className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm md:hidden"


### PR DESCRIPTION
Closes #514

## Changes
- Make the PWA update/offline banner full-width only on mobile and a constrained centered card on larger screens.
- Keep the banner below the mobile navigation z-index so it cannot cover the drawer.
- Add a semantic `header` landmark around the HomePage navigation.
- Add regression tests for banner classes and the HomePage landmark.

## Verification
- `npx vitest run src/__tests__/components/ServiceWorkerUpdateBanner.test.tsx src/__tests__/pages/HomePage.test.tsx`
- `npx tsc --noEmit`
- `npm run lint` (0 errors; existing warnings remain)
- `git diff --check`
- AGY visual review to run after CI completes
