### PR TITLE
feat(ui): establish semantic dark glass tokens (#536)

### DIFF
--- a/frontend/src/assets/styles/globals.css
+++ b/frontend/src/assets/styles/globals.css
@@ -140,22 +140,21 @@
   --aspect-sextile: #3B82F6;
 }
 
-/* Dark Mode Overrides */
+/* Theme compatibility aliases. Semantic roles above remain stable while legacy consumers migrate. */
 .dark {
   --color-background: var(--color-background-dark);
-  --color-surface: var(--color-surface-dark);
+  --color-surface-legacy: var(--color-surface-dark);
   --color-text-primary: #ffffff;
   --color-text-secondary: #a0aec0;
-  --color-border: rgba(255, 255, 255, 0.1);
+  --color-border-legacy: rgba(255, 255, 255, 0.1);
 }
 
-/* Light Mode Overrides */
 .light {
   --color-background: var(--color-background-light);
-  --color-surface: var(--color-surface-light);
+  --color-surface-legacy: var(--color-surface-light);
   --color-text-primary: #1a202c;
   --color-text-secondary: #4a5568;
-  --color-border: rgba(0, 0, 0, 0.1);
+  --color-border-legacy: rgba(0, 0, 0, 0.1);
 }
 
 /* ===================================

--- a/frontend/src/assets/styles/globals.css
+++ b/frontend/src/assets/styles/globals.css
@@ -25,7 +25,34 @@
    DESIGN TOKENS - CSS Variables
    =================================== */
 :root {
-  /* Colors - Primary */
+  /* Semantic dark-cosmic UI contract. Keep component code on roles, not raw palette values. */
+  --color-canvas: #0b0d17;
+  --color-surface: rgba(20, 22, 39, 0.72);
+  --color-surface-elevated: rgba(29, 31, 54, 0.9);
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-border-strong: rgba(167, 139, 250, 0.32);
+  --color-text: #f8fafc;
+  --color-text-muted: #cbd5e1;
+  --color-text-subtle: #94a3b8;
+  --color-accent: #a78bfa;
+  --color-accent-secondary: #67e8f9;
+  --color-focus: #67e8f9;
+  --color-success: #6ee7b7;
+  --color-warning: #fbbf24;
+  --color-danger: #fda4af;
+  --radius-sm: 0.375rem;
+  --radius-md: 0.625rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.5rem;
+  --radius-pill: 9999px;
+  --shadow-surface: 0 12px 36px rgba(0, 0, 0, 0.18);
+  --shadow-elevated: 0 20px 60px rgba(0, 0, 0, 0.3);
+  --shadow-overlay: 0 28px 90px rgba(0, 0, 0, 0.44);
+  --motion-fast: 120ms;
+  --motion-normal: 180ms;
+  --motion-slow: 260ms;
+
+  /* Legacy aliases remain temporarily for migrated consumers. */
   --color-primary: #6b3de1;
   --color-primary-dark: #5a32c0;
   --color-primary-light: #a78bfa;

--- a/frontend/src/utils/__tests__/design-tokens.test.ts
+++ b/frontend/src/utils/__tests__/design-tokens.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { UI_TOKENS } from '../../utils/design-tokens';
+
+describe('UI_TOKENS', () => {
+  it('exposes semantic roles for every shared visual layer', () => {
+    expect(UI_TOKENS.color.canvas).toBe('var(--color-canvas)');
+    expect(UI_TOKENS.color.surfaceElevated).toBe('var(--color-surface-elevated)');
+    expect(UI_TOKENS.color.focus).toBe('var(--color-focus)');
+    expect(UI_TOKENS.elevation.overlay).toBe('var(--shadow-overlay)');
+    expect(UI_TOKENS.radius.pill).toBe('var(--radius-pill)');
+    expect(UI_TOKENS.motion.normal).toBe('var(--motion-normal)');
+  });
+
+  it('does not expose page-specific component values', () => {
+    expect(Object.keys(UI_TOKENS.color)).not.toContain('cardBackground');
+    expect(Object.keys(UI_TOKENS.color)).not.toContain('modalBackground');
+  });
+});

--- a/frontend/src/utils/__tests__/design-tokens.test.ts
+++ b/frontend/src/utils/__tests__/design-tokens.test.ts
@@ -7,11 +7,14 @@ import { ASPECT_COLORS, COSMIC_COLORS, PLANET_COLORS, UI_TOKENS, ZODIAC_COLORS }
 const testDirectory = dirname(fileURLToPath(import.meta.url));
 const globalsCss = readFileSync(resolve(testDirectory, '../../assets/styles/globals.css'), 'utf8');
 
+const cssVariable = (name: string) => new RegExp(`^[ \\t]*--${name}\\s*:`, 'm');
+
 describe('UI_TOKENS', () => {
-  it('references declarations in the canonical loaded stylesheet', () => {
+  it('references exact declarations in the canonical loaded stylesheet', () => {
     for (const category of Object.values(UI_TOKENS)) {
       for (const reference of Object.values(category)) {
-        expect(globalsCss).toContain(reference.replace('var(', '').replace(')', ''));
+        const variableName = reference.slice(6, -1);
+        expect(globalsCss).toMatch(cssVariable(variableName));
       }
     }
   });
@@ -21,10 +24,21 @@ describe('UI_TOKENS', () => {
     expect(Object.keys(UI_TOKENS.color)).not.toContain('modalBackground');
   });
 
-  it('preserves existing chart color contracts', () => {
-    expect(COSMIC_COLORS.pageBg).toBe('#0B0D17');
-    expect(PLANET_COLORS.Sun).toBe('#FFD700');
-    expect(ASPECT_COLORS.trine).toBe('#00FF00');
-    expect(ZODIAC_COLORS.Aries).toBe('#FF4136');
+  it('preserves every existing chart color contract', () => {
+    expect(COSMIC_COLORS).toEqual({
+      pageBg: '#0B0D17', cardBg: 'rgba(20, 22, 39, 0.7)', cardBgSolid: '#141627',
+      border: '#2f2645', borderSubtle: 'rgba(255, 255, 255, 0.08)', textPrimary: '#ffffff',
+      textSecondary: '#cbd5e1', textBody: '#94a3b8', accent: '#6b3de1', accentGlow: 'rgba(107, 61, 225, 0.25)',
+    });
+    expect(PLANET_COLORS).toEqual({
+      Sun: '#FFD700', Moon: '#C0C0C0', Mercury: '#87CEEB', Venus: '#FF69B4', Mars: '#FF4500',
+      Jupiter: '#FF8C00', Saturn: '#8B4513', Uranus: '#00CED1', Neptune: '#4169E1', Pluto: '#8B0000',
+      NorthNode: '#9370DB', SouthNode: '#9370DB', Chiron: '#BC8F8F',
+    });
+    expect(ASPECT_COLORS).toEqual({ conjunction: '#FF0000', opposition: '#FF4500', trine: '#00FF00', square: '#FF8C00', sextile: '#4169E1', quincunx: '#9370DB' });
+    expect(ZODIAC_COLORS).toEqual({
+      Aries: '#FF4136', Taurus: '#2ECC40', Gemini: '#FFDC00', Cancer: '#B10DC9', Leo: '#FF851B', Virgo: '#3D9970',
+      Libra: '#0074D9', Scorpio: '#85144b', Sagittarius: '#FF6347', Capricorn: '#5dade2', Aquarius: '#7FDBFF', Pisces: '#39CCCC',
+    });
   });
 });

--- a/frontend/src/utils/__tests__/design-tokens.test.ts
+++ b/frontend/src/utils/__tests__/design-tokens.test.ts
@@ -1,18 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { UI_TOKENS } from '../../utils/design-tokens';
+import { ASPECT_COLORS, COSMIC_COLORS, PLANET_COLORS, UI_TOKENS, ZODIAC_COLORS } from '../../utils/design-tokens';
+
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const globalsCss = readFileSync(resolve(testDirectory, '../../assets/styles/globals.css'), 'utf8');
 
 describe('UI_TOKENS', () => {
-  it('exposes semantic roles for every shared visual layer', () => {
-    expect(UI_TOKENS.color.canvas).toBe('var(--color-canvas)');
-    expect(UI_TOKENS.color.surfaceElevated).toBe('var(--color-surface-elevated)');
-    expect(UI_TOKENS.color.focus).toBe('var(--color-focus)');
-    expect(UI_TOKENS.elevation.overlay).toBe('var(--shadow-overlay)');
-    expect(UI_TOKENS.radius.pill).toBe('var(--radius-pill)');
-    expect(UI_TOKENS.motion.normal).toBe('var(--motion-normal)');
+  it('references declarations in the canonical loaded stylesheet', () => {
+    for (const category of Object.values(UI_TOKENS)) {
+      for (const reference of Object.values(category)) {
+        expect(globalsCss).toContain(reference.replace('var(', '').replace(')', ''));
+      }
+    }
   });
 
   it('does not expose page-specific component values', () => {
     expect(Object.keys(UI_TOKENS.color)).not.toContain('cardBackground');
     expect(Object.keys(UI_TOKENS.color)).not.toContain('modalBackground');
+  });
+
+  it('preserves existing chart color contracts', () => {
+    expect(COSMIC_COLORS.pageBg).toBe('#0B0D17');
+    expect(PLANET_COLORS.Sun).toBe('#FFD700');
+    expect(ASPECT_COLORS.trine).toBe('#00FF00');
+    expect(ZODIAC_COLORS.Aries).toBe('#FF4136');
   });
 });

--- a/frontend/src/utils/design-tokens.ts
+++ b/frontend/src/utils/design-tokens.ts
@@ -36,10 +36,10 @@ export const UI_TOKENS = {
 } as const;
 
 export type UiTokenPath =
-  | keyof typeof UI_TOKENS.color
-  | keyof typeof UI_TOKENS.radius
-  | keyof typeof UI_TOKENS.elevation
-  | keyof typeof UI_TOKENS.motion;
+  | `color.${keyof typeof UI_TOKENS.color}`
+  | `radius.${keyof typeof UI_TOKENS.radius}`
+  | `elevation.${keyof typeof UI_TOKENS.elevation}`
+  | `motion.${keyof typeof UI_TOKENS.motion}`;
 
 export const COSMIC_COLORS = {
   pageBg: '#0B0D17',

--- a/frontend/src/utils/design-tokens.ts
+++ b/frontend/src/utils/design-tokens.ts
@@ -1,3 +1,46 @@
+/** Semantic design roles shared by CSS, Tailwind, and runtime-rendered UI. */
+export const UI_TOKENS = {
+  color: {
+    canvas: 'var(--color-canvas)',
+    surface: 'var(--color-surface)',
+    surfaceElevated: 'var(--color-surface-elevated)',
+    border: 'var(--color-border)',
+    borderStrong: 'var(--color-border-strong)',
+    text: 'var(--color-text)',
+    textMuted: 'var(--color-text-muted)',
+    textSubtle: 'var(--color-text-subtle)',
+    accent: 'var(--color-accent)',
+    accentSecondary: 'var(--color-accent-secondary)',
+    focus: 'var(--color-focus)',
+    success: 'var(--color-success)',
+    warning: 'var(--color-warning)',
+    danger: 'var(--color-danger)',
+  },
+  radius: {
+    sm: 'var(--radius-sm)',
+    md: 'var(--radius-md)',
+    lg: 'var(--radius-lg)',
+    xl: 'var(--radius-xl)',
+    pill: 'var(--radius-pill)',
+  },
+  elevation: {
+    surface: 'var(--shadow-surface)',
+    elevated: 'var(--shadow-elevated)',
+    overlay: 'var(--shadow-overlay)',
+  },
+  motion: {
+    fast: 'var(--motion-fast)',
+    normal: 'var(--motion-normal)',
+    slow: 'var(--motion-slow)',
+  },
+} as const;
+
+export type UiTokenPath =
+  | keyof typeof UI_TOKENS.color
+  | keyof typeof UI_TOKENS.radius
+  | keyof typeof UI_TOKENS.elevation
+  | keyof typeof UI_TOKENS.motion;
+
 export const COSMIC_COLORS = {
   pageBg: '#0B0D17',
   cardBg: 'rgba(20, 22, 39, 0.7)',
@@ -12,41 +55,16 @@ export const COSMIC_COLORS = {
 } as const;
 
 export const PLANET_COLORS = {
-  Sun: '#FFD700',
-  Moon: '#C0C0C0',
-  Mercury: '#87CEEB',
-  Venus: '#FF69B4',
-  Mars: '#FF4500',
-  Jupiter: '#FF8C00',
-  Saturn: '#8B4513',
-  Uranus: '#00CED1',
-  Neptune: '#4169E1',
-  Pluto: '#8B0000',
-  NorthNode: '#9370DB',
-  SouthNode: '#9370DB',
-  Chiron: '#BC8F8F',
+  Sun: '#FFD700', Moon: '#C0C0C0', Mercury: '#87CEEB', Venus: '#FF69B4',
+  Mars: '#FF4500', Jupiter: '#FF8C00', Saturn: '#8B4513', Uranus: '#00CED1',
+  Neptune: '#4169E1', Pluto: '#8B0000', NorthNode: '#9370DB', SouthNode: '#9370DB', Chiron: '#BC8F8F',
 } as const;
 
 export const ASPECT_COLORS = {
-  conjunction: '#FF0000',
-  opposition: '#FF4500',
-  trine: '#00FF00',
-  square: '#FF8C00',
-  sextile: '#4169E1',
-  quincunx: '#9370DB',
+  conjunction: '#FF0000', opposition: '#FF4500', trine: '#00FF00', square: '#FF8C00', sextile: '#4169E1', quincunx: '#9370DB',
 } as const;
 
 export const ZODIAC_COLORS = {
-  Aries: '#FF4136',
-  Taurus: '#2ECC40',
-  Gemini: '#FFDC00',
-  Cancer: '#B10DC9',
-  Leo: '#FF851B',
-  Virgo: '#3D9970',
-  Libra: '#0074D9',
-  Scorpio: '#85144b',
-  Sagittarius: '#FF6347',
-  Capricorn: '#5dade2',
-  Aquarius: '#7FDBFF',
-  Pisces: '#39CCCC',
+  Aries: '#FF4136', Taurus: '#2ECC40', Gemini: '#FFDC00', Cancer: '#B10DC9', Leo: '#FF851B', Virgo: '#3D9970',
+  Libra: '#0074D9', Scorpio: '#85144b', Sagittarius: '#FF6347', Capricorn: '#5dade2', Aquarius: '#7FDBFF', Pisces: '#39CCCC',
 } as const;


### PR DESCRIPTION
Closes #536

## Foundation scope
- Adds semantic dark-cosmic UI roles for canvas, surfaces, borders, text, accents, feedback, elevation, radius, and motion.
- Keeps existing palette exports compatible for current chart consumers.
- Adds an exact token/CSS contract test before shared primitive migration.
- Uses the loaded `globals.css` stylesheet as the canonical source.
- Keeps legacy `.dark`/`.light` aliases separate from semantic roles.

## Accessibility scope boundary
This PR establishes token names and does not claim WCAG compliance by itself. Border contrast, focus visibility, component semantics, reduced motion, and page-level accessibility are verified when tokens are adopted by shared primitives and route families in follow-up PRs.

## Validation
- Targeted Vitest: passed.
- Frontend TypeScript: passed.
- Frontend lint: passed with existing warnings, 0 errors.

## Review gates
- Executor: Luna xhigh.
- Independent reviewer: Sol xhigh required before merge.
- Follow-up PRs add shared primitives and route migrations.