### PR TITLE
fix(#530): validate card history pagination

### DIFF
--- a/backend/src/__tests__/controllers/card.controller.test.ts
+++ b/backend/src/__tests__/controllers/card.controller.test.ts
@@ -265,7 +265,7 @@ describe('Card Controller', () => {
       expect(mockCardService.getUserCards).toHaveBeenCalledWith(mockUser.id, 20, 0);
       expect(res.json).toHaveBeenCalledWith({
         success: true,
-        data: { cards: [mockCard], limit: 20, offset: 0 },
+        data: { cards: [mockCard], page: 1, limit: 20, offset: 0 },
       });
     });
 
@@ -277,17 +277,30 @@ describe('Card Controller', () => {
 
       expect(res.json).toHaveBeenCalledWith({
         success: true,
-        data: { cards: [], limit: 20, offset: 0 },
+        data: { cards: [], page: 1, limit: 20, offset: 0 },
       });
     });
 
     it('should enforce max limit of 50', async () => {
-      const req = buildReq({ query: { limit: '200', offset: '5' } });
+      const req = buildReq({ query: { page: 2, limit: '200' } });
       mockCardService.getUserCards.mockResolvedValue([]);
 
       await getCardHistory(req, res, next);
 
-      expect(mockCardService.getUserCards).toHaveBeenCalledWith(mockUser.id, 50, 5);
+      expect(mockCardService.getUserCards).toHaveBeenCalledWith(mockUser.id, 50, 50);
+    });
+
+    it('should calculate the database offset from the validated page', async () => {
+      const req = buildReq({ query: { page: 2, limit: 10 } });
+      mockCardService.getUserCards.mockResolvedValue([]);
+
+      await getCardHistory(req, res, next);
+
+      expect(mockCardService.getUserCards).toHaveBeenCalledWith(mockUser.id, 10, 10);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: { cards: [], page: 2, limit: 10, offset: 10 },
+      });
     });
 
     it('should forward service errors to next()', async () => {

--- a/backend/src/__tests__/utils/validators.test.ts
+++ b/backend/src/__tests__/utils/validators.test.ts
@@ -10,6 +10,7 @@ import {
   createChartSchema,
   calculateTransitsSchema,
   paginationSchema,
+  cardHistoryPaginationSchema,
   validateBody,
   validateQuery,
 } from '../../utils/validators';
@@ -355,6 +356,23 @@ describe('Validators', () => {
       const result = paginationSchema.safeParse(data);
 
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe('cardHistoryPaginationSchema', () => {
+    it('rejects the legacy unvalidated offset query', () => {
+      const result = cardHistoryPaginationSchema.safeParse({ offset: '-1', limit: 20 });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('coerces page and limit while keeping only the documented fields', () => {
+      const result = cardHistoryPaginationSchema.safeParse({ page: '2', limit: '10' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ page: 2, limit: 10 });
+      }
     });
   });
 

--- a/backend/src/modules/cards/controllers/card.controller.ts
+++ b/backend/src/modules/cards/controllers/card.controller.ts
@@ -99,8 +99,9 @@ export const getPublicCard = asyncHandler(async (req: Request, res: Response) =>
  * @access  Private
  */
 export const getCardHistory = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-  const limit = Math.min(parseInt(req.query.limit as string) || 20, 50);
-  const offset = parseInt(req.query.offset as string) || 0;
+  const page = Math.max(parseInt(req.query.page as string) || 1, 1);
+  const limit = Math.min(Math.max(parseInt(req.query.limit as string) || 20, 1), 50);
+  const offset = (page - 1) * limit;
 
   const cards = await cardService.getUserCards(req.user.id, limit, offset);
 
@@ -108,6 +109,7 @@ export const getCardHistory = asyncHandler(async (req: AuthenticatedRequest, res
     success: true,
     data: {
       cards,
+      page,
       limit,
       offset,
     },

--- a/backend/src/modules/cards/routes/card.routes.ts
+++ b/backend/src/modules/cards/routes/card.routes.ts
@@ -11,7 +11,7 @@ import {
   validateBody,
   validateQuery,
   validateParams,
-  paginationSchema,
+  cardHistoryPaginationSchema,
   uuidParamSchema,
   shareTokenParamSchema,
 } from '../../../utils/validators';
@@ -145,7 +145,7 @@ router.post(
  *       200:
  *         description: Paginated card history
  */
-router.get('/history', authenticate, validateQuery(paginationSchema), getCardHistory);
+router.get('/history', authenticate, validateQuery(cardHistoryPaginationSchema), getCardHistory);
 
 /**
  * @openapi

--- a/backend/src/utils/validators.ts
+++ b/backend/src/utils/validators.ts
@@ -104,6 +104,8 @@ export const paginationSchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),
 });
 
+export const cardHistoryPaginationSchema = paginationSchema.strict();
+
 // Calendar event validators
 export const createCalendarEventSchema = z.object({
   event_type: z.string().min(1).max(100),


### PR DESCRIPTION
Closes #530

Strict TDD implementation for card history: page/limit contract, strict query validation rejecting legacy offset, bounded offset calculation, stable response metadata, focused regression coverage.