### PR TITLE
fix(#546): restore Vite 8 dependency scanning

### DIFF
--- a/frontend/src/components/UsageMeter.tsx
+++ b/frontend/src/components/UsageMeter.tsx
@@ -163,7 +163,10 @@ export const UsageMeter: React.FC<UsageMeterProps> = ({
         <span className="text-xs text-slate-200 block mb-2">Plan includes:</span>
         <ul className="list-none p-0 m-0 flex flex-wrap gap-1.5 gap-x-3">
           {tierConfig.features.map((feature) => (
-            <li key={feature} className="text-xs text-slate-200 relative pl-3.5 before:content-['\2713'] before:absolute before:left-0 before:text-green-500">{feature}</li>
+            <li key={feature} className="text-xs text-slate-200 relative flex items-center gap-1.5">
+              <span data-testid="tier-feature-checkmark" aria-hidden="true" className="text-green-500">✓</span>
+              {feature}
+            </li>
           ))}
         </ul>
       </div>

--- a/frontend/src/components/__tests__/UsageMeter.test.tsx
+++ b/frontend/src/components/__tests__/UsageMeter.test.tsx
@@ -163,6 +163,17 @@ describe('UsageMeter', () => {
       expect(screen.getByText('1000 charts')).toBeInTheDocument();
       expect(screen.getByText('Priority support')).toBeInTheDocument();
     });
+
+    it('should render a visible decorative checkmark for every included feature', () => {
+      const { container } = render(<UsageMeter {...defaultProps} tier="free" />);
+
+      const checkmarks = container.querySelectorAll('[data-testid="tier-feature-checkmark"]');
+      expect(checkmarks).toHaveLength(3);
+      checkmarks.forEach((checkmark) => {
+        expect(checkmark).toHaveTextContent('✓');
+        expect(checkmark).toHaveAttribute('aria-hidden', 'true');
+      });
+    });
   });
 
   describe('Accessibility', () => {


### PR DESCRIPTION
Closes #546

## Summary
- Replaces the deprecated `\2713` Tailwind pseudo-element content escape with an explicit decorative checkmark element.
- Preserves the visible plan-feature indicator while keeping it out of the accessibility tree.
- Adds a focused regression test covering the checkmarks.

## Reproduction / validation
Before the change, Vite 8/Rolldown reported a deprecated octal escape and skipped dependency pre-bundling while starting the frontend. After this change, the dev server reaches ready state without that dependency-scan failure.

- `npx vitest run src/components/__tests__/UsageMeter.test.tsx` — 28 passed
- `npx tsc --noEmit` (frontend) — passed
- `npm run lint --workspace=frontend` — passed (184 pre-existing warnings, 0 errors)
- `npm run build --workspace=frontend` — passed
- `git diff --check` — passed
- Real-browser landing-page review: screenshots captured at 1440px, 768px, 390px, and 320px; no new horizontal overflow at 320px/390px. Existing off-canvas mobile drawer accessibility defect was re-verified and documented on #518.

No thresholds, masks, skips, or error suppression were added.
